### PR TITLE
extend ingest to consume json data from memory

### DIFF
--- a/bin/acelyzer.py
+++ b/bin/acelyzer.py
@@ -16,7 +16,8 @@ from aiu_trace_analyzer.core.acelyzer import Acelyzer
 
 def main(input_args=None) -> None:
     # this is just a wrapper, processing runs as part of instance creation right now
-    Acelyzer(input_args)
+    acelyzer = Acelyzer(input_args)
+    acelyzer.run()
 
 if __name__ == "__main__":
     if enable_tool_profiler:

--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -98,7 +98,7 @@ class Acelyzer:
         "stage_profile": "profiles/everything.json"
     }
 
-    def __init__(self, in_args=None):
+    def __init__(self, in_args=None, in_data=None):
         print(in_args)
         self.args = self.parse_inputs(in_args)
 
@@ -114,9 +114,18 @@ class Acelyzer:
 
         self.frequency_scale = self.args.freq[0] / self.args.freq[1]
 
+        if in_data is not None and "api://" in self.args.input:
+            self.direct_data = memoryview(in_data)
+        else:
+            self.direct_data = None
+
+    def run(self) -> int:
         # setup/configure data ingestion
         try:
-            importer = ingest.MultifileIngest(source_uri=self.args.input, show_warnings=(not self.args.disable_input_warnings))
+            importer = ingest.MultifileIngest(
+                source_uri=self.args.input,
+                show_warnings=(not self.args.disable_input_warnings),
+                direct_data=self.direct_data)
         except FileNotFoundError:
             sys.exit(1)
 
@@ -148,6 +157,7 @@ class Acelyzer:
         rc = dr.run()
 
         aiulog.log(aiulog.INFO, "Finishing Test parser. Return code=", rc)
+        return rc
 
     def parse_inputs(self, args=None):
         # to include default value in --help output

--- a/src/aiu_trace_analyzer/ingest/ingestion.py
+++ b/src/aiu_trace_analyzer/ingest/ingestion.py
@@ -8,11 +8,12 @@ import math
 import aiu_trace_analyzer.logger as aiulog
 from aiu_trace_analyzer.types import TraceEvent, GlobalIngestData
 
-class AbstractTraceIngest:
 
-    FTYPE_LOG=0
-    FTYPE_JSON=1
-    FTYPE_PFTRACE=2
+class AbstractTraceIngest:
+    FTYPE_LOG = 0
+    FTYPE_JSON = 1
+    FTYPE_PFTRACE = 2
+    FTYPE_API = 3
 
     WARN_MSG_MAP = {
         "zero_duration": "detected 'CompleteEvent' type (ph=X) of zero duration. This should be an 'InstantEvent' type (ph=i). Events skipped:",
@@ -25,7 +26,12 @@ class AbstractTraceIngest:
     Each emitted event must be a python dictionary object
     It's required to emit one event at a time until the source is exhausted.
     '''
-    def __init__(self, source_uri, jobdata = GlobalIngestData(), scale=1.0, show_warnings: bool = True) -> None:
+    def __init__(
+            self,
+            source_uri,
+            jobdata: GlobalIngestData = GlobalIngestData(),
+            scale: float = 1.0,
+            show_warnings: bool = True) -> None:
         self.source_uri = source_uri
         self.jobhash = jobdata.add_job_info(source_uri)
         self.scale = scale
@@ -33,7 +39,8 @@ class AbstractTraceIngest:
         self.rank_pid = -1
         self.show_warnings = show_warnings
         self.warnings = {}
-        assert scale>0.0, 'Scale parameter needs to be >0.0'
+        self._initialized = False
+        assert scale > 0.0, 'Scale parameter needs to be >0.0'
 
     def __del__(self):
         if self.show_warnings:
@@ -49,7 +56,7 @@ class AbstractTraceIngest:
     def __next__(self) -> TraceEvent:
         raise NotImplementedError("Class %s doesn't implement __next__" % (self.__class__.__name__))
 
-    def detect_ftype(self, fname) -> bool:
+    def detect_ftype(self, fname: str) -> bool:
         # TODO: implement a more thorough way to distinguish log and json, for now just check for '.json'
         if ".json" in fname:
             return self.FTYPE_JSON
@@ -57,8 +64,10 @@ class AbstractTraceIngest:
             return self.FTYPE_PFTRACE
         elif ".log" in fname:
             return self.FTYPE_LOG
+        elif fname.startswith("api://"):
+            return self.FTYPE_API
 
-        with open(fname,'r') as f:
+        with open(fname, 'r') as f:
             json_re = re.compile(r"[{}\[\]]")
             log_re = re.compile(r"[0-2]\d:0")
             for line in f:
@@ -73,9 +82,8 @@ class AbstractTraceIngest:
                     return self.FTYPE_PFTRACE
 
     def ftype_to_str(self, ftype):
-        prl = ["FTYPE_LOG", "FTYPE_JSON", "FTYPE_PFTRACE"]
+        prl = ["FTYPE_LOG", "FTYPE_JSON", "FTYPE_PFTRACE", "FTYPE_API"]
         return prl[ftype]
-
 
     # update event data with things like ts-offset or ts-scaling
     def updated_event(self, event: TraceEvent) -> TraceEvent:
@@ -101,58 +109,75 @@ class AbstractTraceIngest:
             except ValueError:
                 event["tid"] = hash(event["tid"])
 
-        if event["ph"] not in ["F","f","s","t","C"]:
+        if event["ph"] not in ["F", "f", "s", "t", "C"]:
             if "args" in event:
                 event["args"]["jobhash"] = self.jobhash
             elif "attr" in event:
                 event["attr"]["jobhash"] = self.jobhash
             else:
-                event["args"] = { "jobhash": self.jobhash }
+                event["args"] = {"jobhash": self.jobhash}
         return event
 
 
-
 class JsonEventTraceIngest(AbstractTraceIngest):
+    '''
+    JSON trace ingestion
+    Reading events from a json data and emitting the containing events one by one.
+    The input can either just contain a list of json events
+    or fully formatted trace data where only the 'traceEvents' section is iterated.
+    '''
     # time-stamp gaps may come out of order, give the sequence checking some slack...
     ts_tolerance = 1000000.0
 
-    '''
-    JSON trace ingestion
-    Reading events from a json trace file and emitting the containing events one by one.
-    The input can either be a file just containing a list of json events
-    or a fully formatted trace file where only the 'traceEvents' section is iterated.
-    '''
-    def __init__(self, source_uri, scale=1.0, test=False, show_warnings: bool = True) -> None:
-        super().__init__(source_uri, scale=scale, show_warnings=show_warnings)
+    def __init__(
+            self,
+            source_uri,
+            jobdata: GlobalIngestData,
+            scale: float = 1.0,
+            keep_processed: bool = False,
+            show_warnings: bool = True) -> None:
+        super().__init__(source_uri, jobdata=jobdata, scale=scale, show_warnings=show_warnings)
+
+        self.data = {}
         self.last_ts = 0.0
         self.pending_close = False
+        self.keep_processed = keep_processed
 
-        with open(self.source_uri, 'r') as sourcefile:
-            self.data = json.load(sourcefile)
-            if "displayTimeUnit" in self.data:
-                if self.data["displayTimeUnit"] == "ms":
-                    self.scale = 1000
-                elif self.data["displayTimeUnit"] == "ns":
-                    self.scale = 1
-                else:
-                    raise NotImplementedError(f'Time Scale detection for {self.data["displayTimeUnit"]} not implemented.')
-            if "distributedInfo" in self.data and "rank" in self.data["distributedInfo"]:
-                self.rank_pid = self.data["distributedInfo"]["rank"]
-                aiulog.log(aiulog.DEBUG, "INGEST: Detected distributedInfo Rank", self.rank_pid)
+    def _initialize_data(self, data_stream) -> None:
+        self.data = data_stream
+        if "displayTimeUnit" in self.data:
+            if self.data["displayTimeUnit"] == "ms":
+                self.scale = 1000
+            elif self.data["displayTimeUnit"] == "ns":
+                self.scale = 1
+            else:
+                raise NotImplementedError(f'Time Scale detection for {self.data["displayTimeUnit"]} not implemented.')
+        if "distributedInfo" in self.data and "rank" in self.data["distributedInfo"]:
+            self.rank_pid = self.data["distributedInfo"]["rank"]
+            aiulog.log(aiulog.DEBUG, "INGEST: Detected distributedInfo Rank", self.rank_pid)
 
-            if "otherData" in self.data and "Application" in self.data["otherData"] and "Acelyzer" in self.data["otherData"]["Application"]:
-                if test is False:
-                    aiulog.log(aiulog.WARN, "INGEST: Attempting to import a json file that had been processed by acelyzer already. Dropping ALL Events from file", self.source_uri)
-                    self.data["traceEvents"] = []
-                else:
-                    self.data = self.data["traceEvents"]
-            if "traceEvents" in self.data:
+        if "otherData" in self.data and \
+            "Application" in self.data["otherData"] and \
+                "Acelyzer" in self.data["otherData"]["Application"]:
+            if self.keep_processed is False:
+                aiulog.log(
+                    aiulog.WARN,
+                    "INGEST: Attempting to import a json file that had been processed by acelyzer already." +
+                    "Dropping ALL Events from file",
+                    self.source_uri)
+                self.data["traceEvents"] = []
+            else:
                 self.data = self.data["traceEvents"]
+        if "traceEvents" in self.data:
+            self.data = self.data["traceEvents"]
 
-            self._len = len(self.data)
-            self._index = 0
+        self._len = len(self.data)
+        print("CREATING _index", self._len)
+        self._index = 0
+        self._initialized = True
 
     def __iter__(self):
+        assert self._initialized == True, "ERROR: Data not initialized."
         return self
 
     def get_next_event(self) -> TraceEvent:
@@ -192,7 +217,8 @@ class JsonEventTraceIngest(AbstractTraceIngest):
                 raise StopIteration
 
         assert open_event, f'Expected to find B-event in {self.source_uri}. Found {event["ph"]}'
-        assert open_event["name"] == event["name"], f'Subsequent B/E events with different names: {open_event["name"]} vs. {event["name"]}'
+        assert open_event["name"] == event["name"], \
+            f'Subsequent B/E events with different names: {open_event["name"]} vs. {event["name"]}'
         if self.pending_close and event["ph"] == "E":
             open_event["ph"] = "X"
             open_event["dur"] = event["ts"] - open_event["ts"]
@@ -212,17 +238,54 @@ class JsonEventTraceIngest(AbstractTraceIngest):
         else:
             assert False, f'Expected to find E-event in {self.source_uri}. Found {event["ph"]}'
 
-    def count_warning(self, warn_class:str) -> None:
+    def count_warning(self, warn_class: str) -> None:
         if warn_class not in self.warnings:
             self.warnings[warn_class] = 0
         self.warnings[warn_class] += 1
-
 
     def __next__(self):
         event = self.build_complete_event()
         while not event:
             event = self.build_complete_event()
         return event
+
+
+class MemoryJsonTraceIngest(JsonEventTraceIngest):
+    _mname_filter = re.compile(r'api://([a-zA-Z]\w+)', re.ASCII)
+    '''
+    JSON trace ingestion from data stream (memory)
+    '''
+    def __init__(
+            self,
+            source_uri,
+            jobdata: GlobalIngestData = GlobalIngestData(),
+            scale: float = 1.0,
+            show_warnings: bool = True,
+            direct_data: memoryview = None):
+        keep_processed = True
+        super().__init__(source_uri, jobdata, scale, keep_processed, show_warnings)
+
+        data = json.loads(direct_data.tobytes())
+        self._initialize_data(data)
+
+
+class JsonFileEventTraceIngest(JsonEventTraceIngest):
+    '''
+    JSON trace ingestion from file
+    '''
+    def __init__(
+            self,
+            source_uri,
+            jobdata: GlobalIngestData = GlobalIngestData(),
+            scale: float = 1.0,
+            keep_processed: bool = False,
+            show_warnings: bool = True):
+        super().__init__(source_uri, jobdata, scale, keep_processed, show_warnings)
+
+        with open(self.source_uri, 'r') as sourcefile:
+            data = json.load(sourcefile)
+
+        self._initialize_data(data)
 
 
 # optional perfetto trace import
@@ -235,7 +298,7 @@ try:
 
             self._index = 0
             self.tp = TraceProcessor(trace=sourceURI)
-            #self.data = self.tp.query('SELECT * FROM slice')
+            # self.data = self.tp.query('SELECT * FROM slice')
             #
             slice_fields = "ts, dur, cat, slice.name as slice_name, slice.id as slice_id, slice.arg_set_id as aid,"
             pt_fields = "utid, thread.name as thread_name, thread.tid as tid, process.upid as upid, process.pid as pid, process.name as process_name"
@@ -245,7 +308,8 @@ try:
             data organized in tables, main table for complete events is 'slice'.
             slices have references to process and thread info via their track_id.
             slices have references to args via their arg_set_id.
-            process info needs to be extracted via a thread_track.parent_id because the process is the parent of a thread track.
+            process info needs to be extracted via a thread_track.parent_id
+             -> because the process is the parent of a thread track.
             the structuring of the args is such that each single arg (k/v) is a single line in 'args' table.
             Args that belong to the same set of args have the same 'arg_set_id'.
             '''
@@ -275,8 +339,8 @@ try:
                 else:
                     val = arg.real_value
 
-                if not arg.arg_set_id in self.argsets:
-                    self.argsets[arg.arg_set_id] = { arg.key: val }
+                if arg.arg_set_id not in self.argsets:
+                    self.argsets[arg.arg_set_id] = {arg.key: val}
                 else:
                     self.argsets[arg.arg_set_id][arg.key] = val
 
@@ -303,6 +367,7 @@ except Exception:
     class ProtobufIngest(AbstractTraceIngest):
         pass
 
+
 class MultifileIngest(AbstractTraceIngest):
 
     '''
@@ -313,45 +378,55 @@ class MultifileIngest(AbstractTraceIngest):
     Performs a round-robin over all files
     and skips any iterators that are exhausted.
     '''
-    def __init__(self, source_uri, show_warnings: bool = True) -> None:
+    def __init__(self, source_uri, show_warnings: bool = True, direct_data: memoryview = None) -> None:
         super().__init__(source_uri, show_warnings=show_warnings)
 
         self.split_pattern = re.compile(r"[,\s]")
-        filelist=self.generate_filelist(source_uri)
+        filelist = self.generate_filelist(source_uri)
         self.ingesters = []
         self.event_front = []
+        self.direct_data = direct_data
+
         aiulog.log(aiulog.INFO, "Ingesting", len(filelist), "files.")
         for ingest in filelist:
-            self.ftype = self.detect_ftype(ingest)
-            if self.ftype == self.FTYPE_JSON:
-                self.ingesters.append( JsonEventTraceIngest(ingest, show_warnings=show_warnings) )
-            elif self.ftype == self.FTYPE_PFTRACE:
-                self.ingesters.append( ProtobufIngest(ingest) )
-            else:
-                aiulog.log(aiulog.ERROR, "Unrecognized file type. file:", ingest )
-            aiulog.log(aiulog.DEBUG, "FileType:", self.ftype_to_str(self.ftype), " detected for:", ingest)
+            self.add_ingester(ingest)
 
-        self.ingest_count = len( self.ingesters )
-        if self.ingest_count <= 0:
+        if len(self.ingesters) == 0:
             aiulog.log(aiulog.ERROR, "No input files found.")
             raise FileNotFoundError()
-        self.ingest_map = [1] * self.ingest_count
+
+    def add_ingester(self, ingest: str) -> bool:
+        _added_new = True
+        self.ftype = self.detect_ftype(ingest)
+        if self.ftype == self.FTYPE_JSON:
+            self.ingesters.append(JsonFileEventTraceIngest(ingest, show_warnings=self.show_warnings))
+        elif self.ftype == self.FTYPE_PFTRACE:
+            self.ingesters.append(ProtobufIngest(ingest))
+        elif self.ftype == self.FTYPE_API:
+            self.ingesters.append(MemoryJsonTraceIngest(ingest, show_warnings=self.show_warnings, direct_data=self.direct_data))
+        else:
+            aiulog.log(aiulog.ERROR, "Unrecognized file type. file:", ingest)
+            _added_new = False
+
+        aiulog.log(aiulog.DEBUG, "FileType:", self.ftype_to_str(self.ftype), " detected for:", ingest)
+        self.ingest_map = [1] * len(self.ingesters)
+        return _added_new
 
     def __iter__(self):
         # prefill an eventfront with the first event from each ingester
-        for idx,_ in enumerate(self.ingesters):
+        for idx, _ in enumerate(self.ingesters):
             try:
                 refill = self.ingesters[idx].__next__()
                 self.update_event_front(refill, idx)
             except StopIteration:
-                self.disable_ingest( idx )
+                self.disable_ingest(idx)
         return self
 
     def __next__(self) -> TraceEvent:
         while True:
             # get the earliest event or end iterator if event_front is empty
             try:
-                event,idx = self.event_front.pop()
+                event, idx = self.event_front.pop()
             except IndexError:
                 raise StopIteration
 
@@ -362,7 +437,7 @@ class MultifileIngest(AbstractTraceIngest):
                     self.update_event_front(refill, idx)
                     break
                 except StopIteration:
-                    self.disable_ingest( idx )
+                    self.disable_ingest(idx)
                     break
         # no extra 'updateEvent' here. That's already done in the specific ingesters
         return event
@@ -371,24 +446,27 @@ class MultifileIngest(AbstractTraceIngest):
         # considered using bisect.insort() but that has no key arg before python 3.10
         # also: both are O(NlogN) but bisect.insort is dominated by array insertion O(N)
         # also: bisect has no reverse order, so pop the earliest TS from list is another O(N) op
-        tsidx = (event, idx) # keep idx with event so we immediately know which iterator/file to use to refill
+        tsidx = (event, idx)   # keep idx with event so we immediately know which iterator/file to use to refill
         self.event_front.append(tsidx)
         # sorting reverse so that list.pop() can be used to emit the event with lowest TS
         self.event_front.sort(reverse=True, key=lambda x: x[0]["ts"])
-        aiulog.log(aiulog.TRACE, "INGEST:", [ e[0]["ts"] for e in self.event_front])
+        aiulog.log(aiulog.TRACE, "INGEST:", [e[0]["ts"] for e in self.event_front])
 
     # return False if no more active ingests available
-    def disable_ingest(self, index ) -> bool:
+    def disable_ingest(self, index) -> bool:
         aiulog.log(aiulog.DEBUG, "IngestIterator", index, "exhausted.")
-        self.ingest_map[ index ] = 0
-        return ( sum( self.ingest_map ) != 0 )
+        self.ingest_map[index] = 0
+        return (sum(self.ingest_map) != 0)
 
     def generate_filelist(self, filestring) -> list[str]:
         fpat_list = self.split_pattern.split(filestring)
         flist = []
         for expanded in fpat_list:
-            subdir,fpat = '/'.join(expanded.split('/')[:-1]), expanded.split('/')[-1]
+            if expanded.startswith("api://"):
+                flist.append(expanded)
+                continue
+            subdir, fpat = '/'.join(expanded.split('/')[:-1]), expanded.split('/')[-1]
             aiulog.log(aiulog.DEBUG, "Opening path:", pathlib.Path(subdir), "Pattern:", fpat)
-            flist += [ f'{x}' for x in list(pathlib.Path(subdir).rglob(fpat)) ]
+            flist += [f'{x}' for x in list(pathlib.Path(subdir).rglob(fpat))]
         aiulog.log(aiulog.INFO, "Reading files:", fpat_list)
         return flist

--- a/tests/aiu_trace_analyzer/core/test_acelyzer_core.py
+++ b/tests/aiu_trace_analyzer/core/test_acelyzer_core.py
@@ -1,0 +1,26 @@
+# Copyright 2024-2025 IBM Corporation
+
+import pytest
+import json
+
+from aiu_trace_analyzer.core.acelyzer import Acelyzer
+
+def test_default_is_everything():
+    args_list = ["-i", "api://jsonbuffer", "--disable_file", "--tb"]
+
+    with open("tests/test_data/basic_event_test_cases.json", 'r') as sourcefile:
+        json_data = json.load(sourcefile)
+
+    jsonbuffer = json.dumps(json_data).encode()
+
+    ace = Acelyzer(args_list, in_data=jsonbuffer)
+    assert ace is not None
+
+    ace.run()
+
+    data = ace.get_output_data()
+    assert isinstance(data, str), "Return data is not a dict."
+
+    result = json.loads(data)
+    print(result.keys())
+    assert "traceEvents" in result, "Return data is missing TraceEvents"

--- a/tests/aiu_trace_analyzer/inout/test_ingestion.py
+++ b/tests/aiu_trace_analyzer/inout/test_ingestion.py
@@ -2,80 +2,84 @@
 
 import pytest
 
-from aiu_trace_analyzer.ingest.ingestion import MultifileIngest, JsonEventTraceIngest, AbstractTraceIngest
-from aiu_trace_analyzer.types import TraceEvent
+from aiu_trace_analyzer.ingest.ingestion import JsonFileEventTraceIngest
+
 
 @pytest.fixture
 def json_input():
     return "tests/test_data/basic_event_test_cases.json"
 
+
 @pytest.fixture
-def json_ingest(json_input) -> JsonEventTraceIngest:
-    return JsonEventTraceIngest(json_input)
+def json_ingest(json_input) -> JsonFileEventTraceIngest:
+    return JsonFileEventTraceIngest(json_input)
 
 
 def test_nonexist_json_file():
     with pytest.raises(FileNotFoundError) as inres:
-        JsonEventTraceIngest("Nonexist_file")
-    assert inres.value.filename=="Nonexist_file"
+        JsonFileEventTraceIngest("Nonexist_file")
+    assert inres.value.filename == "Nonexist_file"
+
 
 def test_invalid_event_ts_scale(json_input):
     with pytest.raises(AssertionError):
-        JsonEventTraceIngest(json_input, scale=-1.0)
+        JsonFileEventTraceIngest(json_input, scale=-1.0)
+
 
 # test the number of generated events from basic_event_test_cases.json is correct
-def test_json_input(json_ingest: JsonEventTraceIngest):
+def test_json_input(json_ingest: JsonFileEventTraceIngest):
     count = 0
     for _ in json_ingest.__iter__():
         count += 1
 
-    assert count==20
+    assert count == 20
 
 
-input_fail_cases:list[tuple[list,Exception,str]] = [
+input_fail_cases: list[tuple[list, Exception, str]] = [
     (
-        [{"ph":"B","name":"openEvent","ts":1,"pid":0},{"ph":"E","name":"closeEvent","ts":10,"pid":0}],
+        [{"ph": "B", "name": "openEvent", "ts": 1, "pid": 0}, {"ph": "E", "name": "closeEvent", "ts": 10, "pid": 0}],
         AssertionError,
         "Subsequent B/E events with different names"
     ),
     (
-        [{"ph":"E","name":"openEvent","ts":1,"pid":0}],
+        [{"ph": "E", "name": "openEvent", "ts": 1, "pid": 0}],
         AssertionError,
         "Expected to find B-event in"
     ),
     (
-        [{"ph":"B","name":"openEvent","ts":1,"pid":0}],
+        [{"ph": "B", "name": "openEvent", "ts": 1, "pid": 0}],
         StopIteration,
         ""
     ),
     (
-        [{"ph":"B","name":"openEvent","ts":1,"pid":0},{"ph":"X","name":"openEvent","ts":2,"pid":0}],
+        [{"ph": "B", "name": "openEvent", "ts": 1, "pid": 0}, {"ph": "X", "name": "openEvent", "ts": 2, "pid": 0}],
         AssertionError,
         "Expected to find E-event in"
     )
 ]
 
+
 @pytest.mark.parametrize('input,error,err_msg', input_fail_cases)
-def test_json_fail_cases(input, error, err_msg, json_ingest: JsonEventTraceIngest):
+def test_json_fail_cases(input, error, err_msg, json_ingest: JsonFileEventTraceIngest):
     # update ingest data and len with input list, as workaround to file input
-    json_ingest.data=input
-    json_ingest._len=len(input)
+    json_ingest.data = input
+    json_ingest._len = len(input)
 
     with pytest.raises(error) as ecode:
         json_ingest.build_complete_event()
     assert err_msg in str(ecode.value)
 
 
-
-@pytest.mark.parametrize('generate_event', [("X","testevent",1.0)], indirect=['generate_event'])
+@pytest.mark.parametrize('generate_event', [("X", "testevent", 1.0)], indirect=['generate_event'])
 def test_event_gen(generate_event):
-    assert generate_event['ph']=='X'
+    assert generate_event['ph'] == 'X'
 
 
 list_test_cases = [
-    (("BE",10), 20),
-    (("X",10), 10)
+    (("BE", 10), 20),
+    (("X",  10), 10)
 ]
+
 
 @pytest.mark.parametrize('generate_event_list, explen', list_test_cases, indirect=['generate_event_list'])
 def test_list_gen(generate_event_list, explen):
@@ -84,20 +88,22 @@ def test_list_gen(generate_event_list, explen):
 
 
 list_iteration_cases = [
-    (("BE",100), 100, json_input),
-    (("X", 100), 100, json_input),
+    (("BE",   100), 100, json_input),
+    (("X",    100), 100, json_input),
     (("XCfs", 100), 400, json_input)
 ]
 
-@pytest.mark.parametrize('generate_event_list, exp_len, json_input',
-                         list_iteration_cases,
-                         indirect=['generate_event_list','json_input'])
+
+@pytest.mark.parametrize(
+        'generate_event_list, exp_len, json_input',
+        list_iteration_cases,
+        indirect=['generate_event_list', 'json_input'])
 def test_json_iterator(generate_event_list, exp_len, json_input):
-    json_importer=JsonEventTraceIngest(source_uri=json_input)
-    json_importer.data=generate_event_list
-    json_importer._len=len(json_importer.data)
-    ts=0.0
-    count=0
+    json_importer = JsonFileEventTraceIngest(source_uri=json_input)
+    json_importer.data = generate_event_list
+    json_importer._len = len(json_importer.data)
+    ts = 0.0
+    count = 0
     for event in json_importer:
         assert event["ph"] in "XCfsbeM", "Unexpected event type"
         assert event["ph"] not in "BE", "Unexpected B/E event."


### PR DESCRIPTION
This PR enables a new way of feeding data into the trace analyzer: via json stream from memory (specifically Python type `bytes`).
This is a step towards usage as a library.

To use this feature, the input file arg needs to start with `api://` and the new option argument for the `Acelyzer` class needs to be present: see [the unit test file](tests/aiu_trace_analyzer/core/test_acelyzer_core.py) for an example usage.
