### PR TITLE
fix program name in usage message

### DIFF
--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -151,7 +151,7 @@ class Acelyzer:
 
     def parse_inputs(self, args=None):
         # to include default value in --help output
-        parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        parser = argparse.ArgumentParser(prog="acelyzer", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         parser.add_argument("-C", "--counter", type=str, nargs='*', default=self.defaults["counter"],
                             choices=["power_ts4", "power_ts3", "coll_bw", "bandwidth", "prep_queue", "rcu_util"],
                             help="Space-separated list of counters to extract/display. Note: power_ts4 and power_ts3 are mutually exclusive.")


### PR DESCRIPTION
When using Acelyzer as a library we're susceptible to misleading usage messages because `ArgumentParser` uses `sys.argv[0]` by [default](https://github.com/python/cpython/blob/74503acba7d6c563aeef307ccf2d0cee141838b0/Lib/argparse.py#L1748):

```
usage: tensorboard [-h] [-C [{power_ts4,power_ts3,coll_bw,bandwidth,prep_queue,rcu_util} ...]] [-c COMPILER_LOG] [-D {0,1,2,3,4}] [-F FILTER]
                   [-f FORMAT] [--freq FREQ] [--flow] [--freq_scaling FREQ_SCALING] -i INPUT [-I] [-k] [--drop_globals] [-M] [-O {drop,tid,async}]
                   [-o OUTPUT] [-R] [-S] [-s] [-t] [-T] [--autopilot_data AUTOPILOT_DATA] [--keep_prep] [--disable_tb] [--tb] [--disable_file]
                   [--flex_ts_fix] [--disable_input_warnings] [--comm_summarize_seq] [--time_unit {ms,ns}]
tensorboard: error: the following arguments are required: -i/--input
```

This PR fixes to to be:

```
usage: acelyzer [-h] [-C [{power_ts4,power_ts3,coll_bw,bandwidth,prep_queue,rcu_util} ...]] [-c COMPILER_LOG] [-D {0,1,2,3,4}]
                [-F FILTER] [-f FORMAT] [--freq FREQ] [--flow] [--freq_scaling FREQ_SCALING] -i INPUT [-I] [-k] [--drop_globals]
                [-M] [-O {drop,tid,async}] [-o OUTPUT] [-R] [-S] [-s] [-t] [-T] [--autopilot_data AUTOPILOT_DATA] [--keep_prep]
                [--disable_tb] [--tb] [--disable_file] [--flex_ts_fix] [--disable_input_warnings] [--comm_summarize_seq]
                [--time_unit {ms,ns}]
acelyzer: error: the following arguments are required: -i/--input
```