### PR TITLE
make default profile paths relative

### DIFF
--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -4,6 +4,7 @@
 import sys
 import argparse
 import math
+import os
 
 from aiu_trace_analyzer.constants import TS_CYCLE_KEY
 from aiu_trace_analyzer.core.stage_profile import StageProfile
@@ -95,7 +96,7 @@ class Acelyzer:
         "time_unit": "ns",
 
         # name of a processing profile
-        "stage_profile": "profiles/everything.json"
+        "stage_profile": os.path.join(os.path.dirname(__file__), "../../../profiles/everything.json")
     }
 
     def __init__(self, in_args=None):

--- a/src/aiu_trace_analyzer/core/stage_profile.py
+++ b/src/aiu_trace_analyzer/core/stage_profile.py
@@ -1,11 +1,12 @@
 # Copyright 2024-2025 IBM Corporation
 
 import json
+import os
 from pathlib import Path
 
 
 class StageProfile:
-    _everything_profile = 'profiles/everything.json'
+    _everything_profile = os.path.join(os.path.dirname(__file__), "../../../profiles/everything.json")
 
     def __init__(self, profile_data: dict):
         self.profile = self._ingest_profile_data(profile_data)


### PR DESCRIPTION
Resolves `FileNotFoundError: [Errno 2] No such file or directory: 'profiles/everything.json'` when no profile is passed to `acelyzer` and `acelyzer` is being called from another file (as a library).