### PR TITLE
Input dialect extension and initial usage

### DIFF
--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -100,7 +100,7 @@ class Acelyzer:
     }
 
     def __init__(self, in_args=None, in_data=None):
-        print(in_args)
+#        print(in_args)
         self.args = self.parse_inputs(in_args)
 
         try:

--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -448,7 +448,6 @@ class Acelyzer:
         # event cleanup for cases where processing functions had added temporary data
         # remove the ts_all from args that got added by cycle_count_to_wallclock
         process.register_stage(callback=event_pipe.flow_data_cleanup)
-        process.register_stage(callback=event_pipe.cycle_count_conversion_cleanup)
         process.register_stage(callback=event_pipe.cleanup_copy_of_device_ts)
 
         tb_refinement_ctx = event_pipe.RefinementContext(exporter)
@@ -457,6 +456,7 @@ class Acelyzer:
 
         # lightweight tb refinement changes cannot be disabled
         process.register_stage(callback=event_pipe.tb_refinement_lightweight, context=tb_refinement_ctx)
+        process.register_stage(callback=event_pipe.cycle_count_conversion_cleanup)
 
         # calculate V2 statistics: relies on some lightweight tb-refinements
         if args.stats:

--- a/src/aiu_trace_analyzer/ingest/ingestion.py
+++ b/src/aiu_trace_analyzer/ingest/ingestion.py
@@ -269,7 +269,7 @@ class MemoryJsonTraceIngest(JsonEventTraceIngest):
         keep_processed = True
         data = json.loads(direct_data.tobytes())
 
-        data_dialect = InputDialectTORCH() if self.is_torch_profile(data) else InputDialectFLEX
+        data_dialect = InputDialectTORCH() if self.is_torch_profile(data) else InputDialectFLEX()
         super().__init__(source_uri, jobdata, data_dialect, scale, keep_processed, show_warnings)
 
         self._initialize_data(data)
@@ -290,7 +290,7 @@ class JsonFileEventTraceIngest(JsonEventTraceIngest):
         with open(source_uri, 'r') as sourcefile:
             data = json.load(sourcefile)
 
-        data_dialect = InputDialectTORCH() if self.is_torch_profile(data) else InputDialectFLEX
+        data_dialect = InputDialectTORCH() if self.is_torch_profile(data) else InputDialectFLEX()
         super().__init__(source_uri, jobdata, data_dialect, scale, keep_processed, show_warnings)
 
         self._initialize_data(data)

--- a/src/aiu_trace_analyzer/ingest/ingestion.py
+++ b/src/aiu_trace_analyzer/ingest/ingestion.py
@@ -6,7 +6,7 @@ import pathlib  # for multifile patterns
 import math
 
 import aiu_trace_analyzer.logger as aiulog
-from aiu_trace_analyzer.types import TraceEvent, GlobalIngestData
+from aiu_trace_analyzer.types import TraceEvent, GlobalIngestData, InputDialect, InputDialectFLEX, InputDialectTORCH
 
 
 class AbstractTraceIngest:
@@ -30,10 +30,11 @@ class AbstractTraceIngest:
             self,
             source_uri,
             jobdata: GlobalIngestData = GlobalIngestData(),
+            data_dialect: InputDialect = InputDialectTORCH(),
             scale: float = 1.0,
             show_warnings: bool = True) -> None:
         self.source_uri = source_uri
-        self.jobhash = jobdata.add_job_info(source_uri)
+        self.jobhash = jobdata.add_job_info(source_uri, data_dialect)
         self.scale = scale
         self.ts_offset = None
         self.rank_pid = -1
@@ -49,6 +50,9 @@ class AbstractTraceIngest:
 
     def set_ts_offset(self, offset):
         self.ts_offset = offset
+
+    def is_torch_profile(self, data: dict) -> bool:
+        return ("deviceProperties" in data)
 
     def __iter__(self):
         raise NotImplementedError("Class %s doesn't implement __iter__" % (self.__class__.__name__))
@@ -133,10 +137,11 @@ class JsonEventTraceIngest(AbstractTraceIngest):
             self,
             source_uri,
             jobdata: GlobalIngestData,
+            data_dialect: InputDialect,
             scale: float = 1.0,
             keep_processed: bool = False,
             show_warnings: bool = True) -> None:
-        super().__init__(source_uri, jobdata=jobdata, scale=scale, show_warnings=show_warnings)
+        super().__init__(source_uri, jobdata=jobdata, data_dialect=data_dialect, scale=scale, show_warnings=show_warnings)
 
         self.data = {}
         self.last_ts = 0.0
@@ -172,12 +177,11 @@ class JsonEventTraceIngest(AbstractTraceIngest):
             self.data = self.data["traceEvents"]
 
         self._len = len(self.data)
-        print("CREATING _index", self._len)
         self._index = 0
         self._initialized = True
 
     def __iter__(self):
-        assert self._initialized == True, "ERROR: Data not initialized."
+        assert self._initialized is True, "ERROR: Data not initialized."
         return self
 
     def get_next_event(self) -> TraceEvent:
@@ -263,9 +267,11 @@ class MemoryJsonTraceIngest(JsonEventTraceIngest):
             show_warnings: bool = True,
             direct_data: memoryview = None):
         keep_processed = True
-        super().__init__(source_uri, jobdata, scale, keep_processed, show_warnings)
-
         data = json.loads(direct_data.tobytes())
+
+        data_dialect = InputDialectTORCH() if self.is_torch_profile(data) else InputDialectFLEX
+        super().__init__(source_uri, jobdata, data_dialect, scale, keep_processed, show_warnings)
+
         self._initialize_data(data)
 
 
@@ -280,10 +286,12 @@ class JsonFileEventTraceIngest(JsonEventTraceIngest):
             scale: float = 1.0,
             keep_processed: bool = False,
             show_warnings: bool = True):
-        super().__init__(source_uri, jobdata, scale, keep_processed, show_warnings)
 
-        with open(self.source_uri, 'r') as sourcefile:
+        with open(source_uri, 'r') as sourcefile:
             data = json.load(sourcefile)
+
+        data_dialect = InputDialectTORCH() if self.is_torch_profile(data) else InputDialectFLEX
+        super().__init__(source_uri, jobdata, data_dialect, scale, keep_processed, show_warnings)
 
         self._initialize_data(data)
 

--- a/src/aiu_trace_analyzer/pipeline/cmpt_collection.py
+++ b/src/aiu_trace_analyzer/pipeline/cmpt_collection.py
@@ -1,16 +1,18 @@
 # Copyright 2024-2025 IBM Corporation
 
 import copy
+import re
 
 import aiu_trace_analyzer.logger as aiulog
-from aiu_trace_analyzer.types import TraceEvent
+from aiu_trace_analyzer.types import TraceEvent, GlobalIngestData
 from aiu_trace_analyzer.pipeline import AbstractContext, AbstractHashQueueContext
+
 
 class QueueingCounterContext(AbstractHashQueueContext):
     def __init__(self) -> None:
         super().__init__()
 
-    def create_counter(self, event:TraceEvent) -> list[TraceEvent]:
+    def create_counter(self, event: TraceEvent) -> list[TraceEvent]:
         qid = event["pid"]
         if qid not in self.queues:
             self.queues[qid] = []
@@ -24,42 +26,46 @@ class QueueingCounterContext(AbstractHashQueueContext):
 
         return self.make_events(ready, event["pid"])
 
-    def update_queues(self, s: float, e: float, qid) -> tuple[list[tuple[float, int]], list[tuple[float,int]]]:
+    def update_queues(self, s: float, e: float, qid) -> tuple[list[tuple[float, int]], list[tuple[float, int]]]:
         ts_list = self.queues[qid]
 
         # per process keep a list of tuples (ts, #overlap)
         #  * gets bumped +1 at event start s and
         #  * gets dropped -1 at event end e
-        if len(ts_list)==0:
-            return [],[ (s,1), (e,0) ]
+        if len(ts_list) == 0:
+            return [], [(s, 1), (e, 0)]
 
         # assuming sorted inbound events, any entry starting before the current can be used to generate a counter
-        ready_list = list(filter(lambda x: x[0]<s, ts_list))
-        last_ready = ready_list[-1][1] if len(ready_list) else 0  # remember the last entry of the ready list as it impacts the count for a new s
+        ready_list = list(filter(lambda x: x[0] < s, ts_list))
+        # remember the last entry of the ready list as it impacts the count for a new s
+        last_ready = ready_list[-1][1] if len(ready_list) else 0
         aiulog.log(aiulog.TRACE, "QCC: ready, s/e", ready_list, s, e)
 
         # the rest depends on whether the timestamps are matching anything existing
         new_list = []
-        mid_se = list(filter(lambda x: s<=x[0] and x[0]<e, ts_list)) # anything that overlaps with current event interval
-        post_e = list(filter(lambda x: e<=x[0], ts_list)) # anything that's past the current event interval
-        last_overlap = mid_se[-1][1] if len(mid_se) else 0 # remember the last entry of the overlap section as it impacts the count for a new e
+        # anything that overlaps with current event interval
+        mid_se = list(filter(lambda x: s <= x[0] and x[0] < e, ts_list))
+        # anything that's past the current event interval
+        post_e = list(filter(lambda x: e <= x[0], ts_list))
+        # remember the last entry of the overlap section as it impacts the count for a new e
+        last_overlap = mid_se[-1][1] if len(mid_se) else 0
 
-        if len(mid_se)==0:
-            new_list.append((s,last_ready+1))
+        if len(mid_se) == 0:
+            new_list.append((s, last_ready + 1))
         else:
-            if s<mid_se[0][0]:
-                new_list.append((s,last_ready+1))
+            if s < mid_se[0][0]:
+                new_list.append((s, last_ready + 1))
 
         # walk the overlap-list and bump the counters
-        for t,c in mid_se:
+        for t, c in mid_se:
             aiulog.log(aiulog.TRACE, "QCC: OverlapBump Mid_se t,c:", t, c)
-            new_list.append((t,c+1))
+            new_list.append((t, c + 1))
 
-        if len(post_e)==0:
-            new_list.append((e,last_overlap))
+        if len(post_e) == 0:
+            new_list.append((e, last_overlap))
         else:
-            if e<post_e[0][0]:
-                new_list.append((e,last_overlap))
+            if e < post_e[0][0]:
+                new_list.append((e, last_overlap))
 
         new_list += post_e
         aiulog.log(aiulog.TRACE, "QCC: new_list", new_list)
@@ -67,14 +73,14 @@ class QueueingCounterContext(AbstractHashQueueContext):
 
     def make_events(self, ready: list[tuple[float, int]], pid) -> list[TraceEvent]:
         revents = []
-        for t,c in ready:
+        for t, c in ready:
             counter = {
                 "ph": "C",
                 "ts": t,
                 "pid": pid,
                 "name": "ConcurrentPreps",
                 "cat": "Pending Prep Events",
-                "args": { "Concurrency": c},
+                "args": {"Concurrency": c},
             }
             revents.append(copy.deepcopy(counter))
         return revents
@@ -82,15 +88,20 @@ class QueueingCounterContext(AbstractHashQueueContext):
     def drain(self) -> list[TraceEvent]:
         revents = []
         while len(self.queues):
-            pid,q = self.queues.popitem()
+            pid, q = self.queues.popitem()
             revents += self.make_events(q, pid)
         return revents
 
+
 def queueing_counter(event: TraceEvent, queue_coll: AbstractContext, keyval: dict) -> list[TraceEvent]:
-    revents = [ event ]
+    revents = [event]
     keep_prep = keyval.get("keep_prep", False)
 
-    if event["ph"] in "X" and "Cmpt Prep" in event["name"]:
+    if event["ph"] in "X":
+        dialect = GlobalIngestData.get_dialect(event["args"]["jobhash"])
+        if re.search(dialect.get("acc_compute_prep"), event["name"]) is None:
+            return revents
+
         if keep_prep:
             revents += queue_coll.create_counter(event)
         else:

--- a/src/aiu_trace_analyzer/profiles/everything.json
+++ b/src/aiu_trace_analyzer/profiles/everything.json
@@ -47,9 +47,9 @@
         {"processing_filter": true},
         {"flow_data_cleanup": true},
         {"cycle_count_conversion_cleanup": true},
-        {"cleanup_copy_of_device_ts": true},
         {"tb_refinement_intrusive": true},
         {"tb_refinement_lightweight": true},
+        {"cleanup_copy_of_device_ts": true},
         {"calculate_stats_v2": true}
     ]
 }

--- a/src/aiu_trace_analyzer/types.py
+++ b/src/aiu_trace_analyzer/types.py
@@ -17,6 +17,8 @@ class InputDialect:
         if category not in cls.categories:
             raise KeyError(f"ERROR: Category {category} is not part of this dialect.")
 
+        if entry == "-":
+            entry = None
         cls.dialect_map[category] = entry
         return True
 
@@ -31,7 +33,39 @@ class InputDialect:
 class InputDialectFLEX(InputDialect):
     _FLEX_DIALECT = {
         "NAME": "FLEX",
-        "AIU_Runtime": "AIU_Roundtrip",
+        "acc_launch_cb": "-",
+        "acc_graph_init": "-",
+        "acc_graph_exec": "Execute Graph",
+        "acc_malloc": "FixupAllocations",
+        "acc_resize_tensor_alloc": "AllocateFrame of graph",
+        "acc_supernode_launch": "Flex Roundtrip",
+        "acc_supernode_exec": "Flex Roundtrip",
+        "acc_node_compute": "Compute of $NodeName",
+        "acc_data_convert": "Compute of $NodeName-HostPrep",
+        "acc_scheduler_init": "SchedulerConstruct",
+        "acc_virtaddr_create": "CreatePipoIovas",
+        "acc_launch_schedule_compute": "ScheduleCompute",
+        "acc_schedule_wait": "WaitForCompletionAndReturnStatus",
+        "acc_dma_prep": "PrepareDmas",
+        "acc_rdma_prep_sync": "PrepareAndSyncRdma",
+        "acc_cache_clear": "LaunchClearScratchpad",
+        "acc_cache_preload": "LaunchPreloadScratchpad",
+        "acc_launch_compute_stream": "LaunchComputeStream",
+        "acc_rdma_barrier1": "Barrier1",
+        "acc_rdma_post_keys": "PostKeys",
+        "acc_rdma_barrier2": "Barrier2",
+        "acc_rdma_fetch_keys": "FetchKeys",
+        "acc_rdma_update_cb": "Update CBs",
+        "acc_rdma_barrier3": "Barrier3",
+        "acc_rdma_check_deadlock": "Deadlock Check",
+        "acc_filetransfer_DtoF": "-",
+        "acc_filetransfer_MtoF": "-",
+        "acc_filetransfer_FtoD": "-",
+        "acc_filetransfer_FtoM": "-",
+        "acc_datatransfer_DtoH": "-",
+        "acc_datatransfer_HtoD": "-",
+        "acc_clock_calibration": "-",
+        "acc_compile_graph": "-",
     }
 
     def __new__(cls):
@@ -45,7 +79,39 @@ class InputDialectFLEX(InputDialect):
 class InputDialectTORCH(InputDialect):
     _TORCH_DIALECT = {
         "NAME": "TORCH",
-        "AIU_Runtime": "AIU_Runtime",
+        "acc_launch_cb": "aiuLaunchControlBlocks",
+        "acc_graph_init": "aiuInitGraph",
+        "acc_graph_exec": "aiuGraphExecution",
+        "acc_malloc": "aiuMalloc",
+        "acc_resize_tensor_alloc": "aiuResizeTensorAllocation",
+        "acc_supernode_launch": "aiuLaunchSuperNode",
+        "acc_supernode_exec": "aiuSuperNodeExecution",
+        "acc_node_compute": "aiuNodeCompute",
+        "acc_data_convert": "aiuDataConvert",
+        "acc_scheduler_init": "aiuInitScheduler",
+        "acc_virtaddr_create": "aiuCreateVirtualAddresses",
+        "acc_launch_schedule_compute": "aiuLaunchScheduleCompute",
+        "acc_schedule_wait": "aiuScheduleWait",
+        "acc_dma_prep": "aiuPrepareDMAs",
+        "acc_rdma_prep_sync": "aiuPrepareAndSyncRDMA",
+        "acc_cache_clear": "aiuClearCache",
+        "acc_cache_preload": "aiuPreloadCache",
+        "acc_launch_compute_stream": "aiuLaunchComputeStream",
+        "acc_rdma_barrier1": "aiuRDMABarrier1",
+        "acc_rdma_post_keys": "aiuPostRDMAKeys",
+        "acc_rdma_barrier2": "aiuRDMABarrier2",
+        "acc_rdma_fetch_keys": "aiuFetchRDMAKeys",
+        "acc_rdma_update_cb": "aiuUpdateRDMACBs",
+        "acc_rdma_barrier3": "aiuRDMABarrier3",
+        "acc_rdma_check_deadlock": "aiuCheckRDMADeadlock",
+        "acc_filetransfer_DtoF": "aiuFileTransferDtoF",
+        "acc_filetransfer_MtoF": "aiuFileTransferMtoF",
+        "acc_filetransfer_FtoD": "aiuFileTransferFtoD",
+        "acc_filetransfer_FtoM": "aiuFileTransferFtoM",
+        "acc_datatransfer_DtoH": "aiuDataTransferDtoH",
+        "acc_datatransfer_HtoD": "aiuDataTransferHtoD",
+        "acc_clock_calibration": "aiuClockCalibration",
+        "acc_compile_graph": "aiuCompileGraph",
     }
 
     def __new__(cls):

--- a/src/aiu_trace_analyzer/types.py
+++ b/src/aiu_trace_analyzer/types.py
@@ -1,11 +1,60 @@
 # Copyright 2024-2025 IBM Corporation
 
-from typing import NamedTuple
 from pathlib import Path
+
 
 # define TraceEvent to be a dictionary for consistency
 class TraceEvent(dict):
     pass
+
+
+class InputDialect:
+    dialect_map = {}
+    categories = set()
+
+    @classmethod
+    def register(cls, category: str, entry: str) -> bool:
+        if category not in cls.categories:
+            raise KeyError(f"ERROR: Category {category} is not part of this dialect.")
+
+        cls.dialect_map[category] = entry
+        return True
+
+    @classmethod
+    def add_category(cls, category: str) -> bool:
+        if category in cls.categories:
+            return False
+        cls.categories.add(category)
+        return True
+
+
+class InputDialectFLEX(InputDialect):
+    _FLEX_DIALECT = {
+        "NAME": "FLEX",
+        "AIU_Runtime": "AIU_Roundtrip",
+    }
+
+    def __new__(cls):
+        if not hasattr(cls, '_instance'):
+            cls._jobmap = {}
+            for c, e in cls._FLEX_DIALECT.items():
+                cls.register(c, e)
+        return super(InputDialectFLEX, cls).__new__(cls)
+
+
+class InputDialectTORCH(InputDialect):
+    _TORCH_DIALECT = {
+        "NAME": "TORCH",
+        "AIU_Runtime": "AIU_Runtime",
+    }
+
+    def __new__(cls):
+        if not hasattr(cls, '_instance'):
+            cls._jobmap = {}
+            for c, e in cls._TORCH_DIALECT.items():
+                cls.add_category(c)
+                cls.register(c, e)
+        return super(InputDialectTORCH, cls).__new__(cls)
 
 
 class GlobalIngestData(object):
@@ -17,16 +66,16 @@ class GlobalIngestData(object):
         return super(GlobalIngestData, cls).__new__(cls)
 
     @classmethod
-    def add_job_info(cls, source_uri: str) -> int:
+    def add_job_info(cls, source_uri: str, data_dialect: InputDialect = None) -> int:
         jobhash = hash(source_uri) % 10000
         if jobhash not in cls._jobmap:
-            cls._jobmap[jobhash] = Path(source_uri).name
+            cls._jobmap[jobhash] = (Path(source_uri).name, data_dialect)
         return jobhash
 
     @classmethod
     def get_job(cls, jobhash: int) -> str:
         try:
-            return cls._jobmap[jobhash]
+            return cls._jobmap[jobhash][0]
         except KeyError:
             print("jobmap empty")
             return "Not Available"


### PR DESCRIPTION
Introducing code to deal with different 'input dialects' (using singleton patterns) for the data ingestion.
Each event already has a reference pointing to it's data source file and this item has been extended to include the dialect so that for each event we can retrieve it's 'dialect'.

Initial usage has been added to tb_refinement and bw computation.
For this to work, the cleanup of the file-reference hash had to be moved to after the tb_refinement stage.
