### PR TITLE
fn_idx in event names inserted in square brackets

### DIFF
--- a/src/aiu_trace_analyzer/ingest/ingestion.py
+++ b/src/aiu_trace_analyzer/ingest/ingestion.py
@@ -34,19 +34,20 @@ class AbstractTraceIngest:
             scale: float = 1.0,
             show_warnings: bool = True) -> None:
         self.source_uri = source_uri
-        self.jobhash = jobdata.add_job_info(source_uri, data_dialect)
         self.scale = scale
         self.ts_offset = None
         self.rank_pid = -1
         self.show_warnings = show_warnings
         self.warnings = {}
         self._initialized = False
+        self.jobhash = jobdata.add_job_info(source_uri, data_dialect)
         assert scale > 0.0, 'Scale parameter needs to be >0.0'
 
     def __del__(self):
-        if self.show_warnings:
+        if hasattr(self, "show_warnings") and self.show_warnings:
             for warnclass, warning in self.warnings.items():
                 aiulog.log(aiulog.WARN, self.source_uri, warnclass, self.WARN_MSG_MAP[warnclass], warning)
+
 
     def set_ts_offset(self, offset):
         self.ts_offset = offset

--- a/src/aiu_trace_analyzer/pipeline/stats.py
+++ b/src/aiu_trace_analyzer/pipeline/stats.py
@@ -242,7 +242,7 @@ def calculate_stats(event: TraceEvent, context: AbstractContext) -> list[TraceEv
         # becames "addmm_N_Matmult Cmpt Exec"
         name_converter = re.compile(r"[_-]\d+")
 
-        stripped_name = name_converter.sub("_N", event["name"])
+        stripped_name = name_converter.sub("_[N]", event["name"])
 
         event_start = event["ts"]
         event_dur = event["dur"]

--- a/src/aiu_trace_analyzer/pipeline/tb_refinement.py
+++ b/src/aiu_trace_analyzer/pipeline/tb_refinement.py
@@ -79,8 +79,8 @@ class RefinementContext(AbstractHashQueueContext):
         match = self.name_converter.search(event["name"])
         if match and "args" in event:
             event["args"]["fn_idx"] = event["name"][match.start()+1:match.end()]
-        # ...and replace it with _N
-            event["name"] = re.sub(self.name_converter, "_N", event["name"], count=1)
+        # ...and replace it with _[N]
+            event["name"] = re.sub(self.name_converter, "_[N]", event["name"], count=1)
 
         if "coll" in str(event["tid"]):
             event["tid"] = 10000+int(str(event["tid"])[4])

--- a/tests/aiu_trace_analyzer/pipeline/test_tb_refinement.py
+++ b/tests/aiu_trace_analyzer/pipeline/test_tb_refinement.py
@@ -18,15 +18,15 @@ def tb_ctx(tmp_path):
 list_events_test_heavy = [
     # regular, simple case for fn-idx removal
     ({"name":"event_123", "pid": 1, "tid": 1, "args": {}},
-     {"name":"event_N", "pid": 1, "tid": 1, "args": {"fn_idx": "123"}}),
+     {"name":"event_[N]", "pid": 1, "tid": 1, "args": {"fn_idx": "123"}}),
 
     # testing for only replacing the first index and keep the rest
     ({"name":"event_123[sync=sgroup_0_s2_321]", "pid": 1, "tid": 1, "args": {}},
-     {"name":"event_N[sync=sgroup_0_s2_321]", "pid": 1, "tid": 1, "args": {"fn_idx": "123"}} ),
+     {"name":"event_[N][sync=sgroup_0_s2_321]", "pid": 1, "tid": 1, "args": {"fn_idx": "123"}} ),
 
     # testing existing fn_idx will be overwritten if it already exists
     ({"name":"event_123", "pid": 1, "tid": 1, "args": {"fn_idx": "321"}},
-     {"name":"event_N", "pid": 1, "tid": 1, "args": {"fn_idx": "123"}}),
+     {"name":"event_[N]", "pid": 1, "tid": 1, "args": {"fn_idx": "123"}}),
 
     # testing with event name without idx
     ({"name":"eventname", "pid": 1, "tid": 1, "args": {}},
@@ -38,7 +38,7 @@ list_events_test_heavy = [
 
     # testing the coll-tid replacement
     ({"name":"event_123", "pid": 1, "tid": "coll1", "args": {}},
-     {"name":"event_N", "pid": 1, "tid": 10001, "args": {"fn_idx": "123"}}),
+     {"name":"event_[N]", "pid": 1, "tid": 10001, "args": {"fn_idx": "123"}}),
 ]
 
 @pytest.mark.parametrize('event_in, reference', list_events_test_heavy)


### PR DESCRIPTION
to prevent mixup of event function index and event names with `N`, the function index is now wrapped in `[]` to make it more robust to identify within the name string (e.g. for event names that contain the character `N`)

additional: added a check for existence of `show_warnings`-attribute