### PR TITLE
fix: multi-file ingest name collision

### DIFF
--- a/src/aiu_trace_analyzer/ingest/ingestion.py
+++ b/src/aiu_trace_analyzer/ingest/ingestion.py
@@ -388,7 +388,7 @@ class MultifileIngest(AbstractTraceIngest):
     and skips any iterators that are exhausted.
     '''
     def __init__(self, source_uri, show_warnings: bool = True, direct_data: memoryview = None) -> None:
-        super().__init__(source_uri, show_warnings=show_warnings)
+        super().__init__("top_level_multifile", show_warnings=show_warnings)
 
         self.split_pattern = re.compile(r"[,\s]")
         filelist = self.generate_filelist(source_uri)


### PR DESCRIPTION
fixing a bug in ingestion:
 * if a single file is provided as input, the jobhash+info initialization is shadowed by the construction of `MultifileIngest` and thus prevents subsequent file-specific settings to take effect when e.g. a json file ingester is created.

fixing by using a static string. This problem would still trigger if someone uses an input file named `top_level_multifile`, though, I'd say it's safe enough because usually input files have `.json` extension or include wildcards.