### PR TITLE
using dialects for detecting kernel/accelerator events

### DIFF
--- a/src/aiu_trace_analyzer/types.py
+++ b/src/aiu_trace_analyzer/types.py
@@ -76,6 +76,7 @@ class InputDialectFLEX(InputDialect):
         "acc_category_kernel": "kernel",
         "acc_category_runtime": "cuda_runtime",
         "acc_compute_prep": "Cmpt Prep$",
+        "acc_kernel": "is.name.Cmpt Exec$",
         "acc_event_cat": "has.args.TS1",
     }
 
@@ -127,6 +128,7 @@ class InputDialectTORCH(InputDialect):
         "acc_category_kernel": "kernel",
         "acc_category_runtime": "cuda_runtime",
         "acc_compute_prep": "Cmpt Prep$",
+        "acc_kernel": "is.cat.kernel",
         "acc_event_cat": "is.cat.kernel",
     }
 


### PR DESCRIPTION
separated kernel detection functions into tools so that dialect-based detection can be reused from multiple places.
subsequent PRs will update other stages. This one deals with tb-refinement only because one of the detection functions has moved out of that stage.

Also addressing an issue with function-idx handling in event names. Need to prevent assuming a function idx to appear anywhere after any `-` in the event name. (eg: `mm_2-bmm_1`: the `1` can never be the fn-idx).