### PR TITLE
pt utilization using dialect

### DIFF
--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -80,7 +80,7 @@ class Acelyzer:
         "config_file": "ace.conf",
 
         # default ideal and SOC Frequency
-        "freq": 560.0,
+        "freq": 1000.0,
         "ideal_freq": 800.0,
 
         # experimental FLEX per-job timestamp correction
@@ -100,7 +100,6 @@ class Acelyzer:
     }
 
     def __init__(self, in_args=None, in_data=None):
-#        print(in_args)
         self.args = self.parse_inputs(in_args)
 
         try:
@@ -113,7 +112,8 @@ class Acelyzer:
         aiulog.loglevel = self.args.loglevel
         aiulog.log(aiulog.INFO, "Starting Test parser")
 
-        self.frequency_scale = self.args.freq[0] / self.args.freq[1]
+        self.freq_soc = self.args.freq[0]
+        self.freq_core = self.args.freq[1]
 
         if in_data is not None and "api://" in self.args.input:
             self.direct_data = memoryview(in_data)
@@ -386,7 +386,8 @@ class Acelyzer:
             rcu_util_ctx = event_pipe.MultiRCUUtilizationContext(
                 compiler_log=args.compiler_log,
                 csv_fname=args.output,
-                scale_factor=self.frequency_scale)
+                soc_freq=self.freq_soc,
+                core_freq=self.freq_core)
             process.register_stage(callback=event_pipe.compute_utilization_fingerprints, context=rcu_util_ctx)
 
         ##############################################################

--- a/src/aiu_trace_analyzer/ingest/ingestion.py
+++ b/src/aiu_trace_analyzer/ingest/ingestion.py
@@ -16,7 +16,8 @@ class AbstractTraceIngest:
     FTYPE_API = 3
 
     WARN_MSG_MAP = {
-        "zero_duration": "detected 'CompleteEvent' type (ph=X) of zero duration. This should be an 'InstantEvent' type (ph=i). Events skipped:",
+        "zero_duration":    "detected 'CompleteEvent' type (ph=X) of zero duration. "
+                            "This should be an 'InstantEvent' type (ph=i). Events skipped:",
         "negative_duration": "Ingestion: detected negative duration event(s). Events ignored:"
     }
 
@@ -47,7 +48,6 @@ class AbstractTraceIngest:
         if hasattr(self, "show_warnings") and self.show_warnings:
             for warnclass, warning in self.warnings.items():
                 aiulog.log(aiulog.WARN, self.source_uri, warnclass, self.WARN_MSG_MAP[warnclass], warning)
-
 
     def set_ts_offset(self, offset):
         self.ts_offset = offset
@@ -95,7 +95,7 @@ class AbstractTraceIngest:
         if "ts" in event:
             event["ts"] *= self.scale
         if "dur" in event:
-            event["dur"] = int(event["dur"] * self.scale)
+            event["dur"] = float(event["dur"] * self.scale)
         if self.rank_pid >= 0:
             event["pid"] = self.rank_pid
 
@@ -151,13 +151,14 @@ class JsonEventTraceIngest(AbstractTraceIngest):
 
     def _initialize_data(self, data_stream) -> None:
         self.data = data_stream
-        if "displayTimeUnit" in self.data:
-            if self.data["displayTimeUnit"] == "ms":
-                self.scale = 1000
-            elif self.data["displayTimeUnit"] == "ns":
-                self.scale = 1
-            else:
-                raise NotImplementedError(f'Time Scale detection for {self.data["displayTimeUnit"]} not implemented.')
+        # removed: display-unit is only for the visualization not the input data
+        # if "displayTimeUnit" in self.data:
+        #     if self.data["displayTimeUnit"] == "ms":
+        #         self.scale = 1000
+        #     elif self.data["displayTimeUnit"] == "ns":
+        #         self.scale = 1
+        #     else:
+        #         raise NotImplementedError(f'Time Scale detection for {self.data["displayTimeUnit"]} not implemented.')
         if "distributedInfo" in self.data and "rank" in self.data["distributedInfo"]:
             self.rank_pid = self.data["distributedInfo"]["rank"]
             aiulog.log(aiulog.DEBUG, "INGEST: Detected distributedInfo Rank", self.rank_pid)
@@ -310,7 +311,8 @@ try:
             # self.data = self.tp.query('SELECT * FROM slice')
             #
             slice_fields = "ts, dur, cat, slice.name as slice_name, slice.id as slice_id, slice.arg_set_id as aid,"
-            pt_fields = "utid, thread.name as thread_name, thread.tid as tid, process.upid as upid, process.pid as pid, process.name as process_name"
+            pt_fields = "utid, thread.name as thread_name, thread.tid as tid, " \
+                "process.upid as upid, process.pid as pid, process.name as process_name"
             self.fields = slice_fields+pt_fields
 
             '''


### PR DESCRIPTION
This PR should enable pt utilization detection for both known json/event dialects.

One concept changed from using cycles to using event duration. This was needed because the Torch profile doesn't contain cycle info.

This change is breaking the current categories table. I'll address this in a subsequent PR and will open an issue to make everyone aware of this temp. break.

summary of changes:
 * acelyzer core: keep frequencies separate as opposed to mingle the input into a scale-factor
 * ingestion: don't mess with the durations and time scales of input events
 * rcu_util:
   *  using wallclock removes the need for cycle scaling,
   * event names with `[N]` fn_idx (Torch) get reversed into their origin form to find the table entries
 * general: bunch of code formatting changes - sorry for the clutter

Tests:
 * pytest updated
 * ran tests with torch and flex examples, where flex examples results compared to previous versions