### PR TITLE
Event handling overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,17 @@ The `-c` argument provides the tool with the log file which is being processed f
 acelyzer -i "${TRACE_DIR}/hap-json-files/hap-bs8-seq256-autopilot-0-34707-job-*.json" -c ${TRACE_GIT}/hap-json-files/hap-bs8-seq256-autopilot-0.log -o hap_trace.json
 ```
 
+An evolving feature is the use of processing profiles (option `-P`) to allow control which processing stages are enabled. By default, the `everything.json` profile is used. Note that the cmdline still overrides the deactivation of stages so that if a stage is not requested via cmdline, its activation in the profile has no effect. When creating a profile, it's currently necessary to start from the everything-profile and set unwanted stages to `false`.
+
 ### Input Files
 
 The tool is capable of ingesting these types of input files:
 
- * json traces: So far this is the primary and supported option. It can be a json file that contains a list of events or another trace file that's formatted after the Trace Event Format. The tool is also capable of processing torch profiler trace files.
+ * json traces: So far this is the primary and supported option. It can be a json file that contains a list of events or another trace file that's formatted after the Trace Event Format. The tool is also capable of processing torch profiler trace files. It attempts to detect the input 'dialect' and adjusts event treatment accordingly.
  * perfetto protobuf files: so far it's able to extract trace events and their arguments from those files. It's not reading counters or other more sophisticated things yet (limited functionality).
 
 There's a basic autodetect function for the file type built in. If the filename extension doesn't indicate the type, it detects log files by their lines with time stamps, it detects json files by finding the initial open parenthesis, and for everything else, it assumes binary format of perfetto.
+
 
 
 ### Output Files

--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -188,6 +188,7 @@ class Acelyzer:
         parser.add_argument("-T", "--sync_to_dev", dest='sync_to_dev', action='store_const', const=True, default=self.defaults["sync_to_dev"], help="When set, use epoch from device timers")
         parser.add_argument("--autopilot_data", type=str, default=self.defaults["autopilot_db"], help="(Not yet implemented) Where to look for kernel category data from runs with 'autopilot=0'.")
         parser.add_argument("--keep_prep", dest="keep_prep", action="store_true", default=False, help="Prep-events are counted and the dropped. Use this option to keep them.")
+        parser.add_argument("--keep_names", dest="keep_names", action="store_true", default=False, help="Keep original event names when using the --tb option. By default most numbers are removed from name for aggregation purposes.")
         parser.add_argument("--disable_tb", dest="tb_refinement", action="store_false", default=self.defaults["tb_refinement"], help="To use Chrome-trace to render timeline, disable TB refinement")
         parser.add_argument("--tb", dest="tb", action="store_true", default=self.defaults["tb"], help="Enable output files for tensorboard.")
         parser.add_argument("--disable_file", dest="save_to_file", action="store_false", default=True, help="Disable output to file (primarily for TensorBoard integration). Prevents output file creation for integrated mode.")
@@ -451,7 +452,7 @@ class Acelyzer:
         process.register_stage(callback=event_pipe.flow_data_cleanup)
         process.register_stage(callback=event_pipe.cleanup_copy_of_device_ts)
 
-        tb_refinement_ctx = event_pipe.RefinementContext(exporter)
+        tb_refinement_ctx = event_pipe.RefinementContext(exporter, keep_names=args.keep_names)
         if args.tb_refinement:
             process.register_stage(callback=event_pipe.tb_refinement_intrusive, context=tb_refinement_ctx)
 

--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -81,7 +81,7 @@ class Acelyzer:
 
         # default ideal and SOC Frequency
         "freq": 1000.0,
-        "ideal_freq": 800.0,
+        "ideal_freq": 1100.0,
 
         # experimental FLEX per-job timestamp correction
         "flex_ts_fix": False,

--- a/src/aiu_trace_analyzer/core/processing.py
+++ b/src/aiu_trace_analyzer/core/processing.py
@@ -42,7 +42,7 @@ class EventProcessor:
     '''
     def register_stage(self, callback, context: procCTX.AbstractContext = None, **kwargs):
         if not self.stage_check.fwd_find_stage(callback.__name__):
-            aiulog.log(aiulog.DEBUG, "DAH: Skipping registration of", callback.__name__, ": disabled in profile.")
+            aiulog.log(aiulog.INFO, "DAH: Skipping registration of", callback.__name__, ": disabled in profile.")
             return
         else:
             aiulog.log(aiulog.DEBUG, "DAH: registering: ", callback.__name__)

--- a/src/aiu_trace_analyzer/export/exporter.py
+++ b/src/aiu_trace_analyzer/export/exporter.py
@@ -124,7 +124,7 @@ class TensorBoardFileTraceExporter(JsonFileTraceExporter):
 
         for event in data:
             rank_id = event[key]
-            if rank_id is not None:
+            if rank_id is not None and isinstance(rank_id, int):
                 if rank_id >= 1000:
                     rank_id -= 1000
 

--- a/src/aiu_trace_analyzer/ingest/ingestion.py
+++ b/src/aiu_trace_analyzer/ingest/ingestion.py
@@ -466,8 +466,8 @@ class MultifileIngest(AbstractTraceIngest):
         tsidx = (event, idx)   # keep idx with event so we immediately know which iterator/file to use to refill
         self.event_front.append(tsidx)
         # sorting reverse so that list.pop() can be used to emit the event with lowest TS
-        self.event_front.sort(reverse=True, key=lambda x: x[0]["ts"])
-        aiulog.log(aiulog.TRACE, "INGEST:", [e[0]["ts"] for e in self.event_front])
+        self.event_front.sort(reverse=True, key=lambda x: x[0]["ts"] if "ts" in x[0] else 0.0)
+        aiulog.log(aiulog.TRACE, "INGEST:", [e[0]["ts"] if "ts" in e[0] else 0.0 for e in self.event_front])
 
     # return False if no more active ingests available
     def disable_ingest(self, index) -> bool:

--- a/src/aiu_trace_analyzer/ingest/ingestion.py
+++ b/src/aiu_trace_analyzer/ingest/ingestion.py
@@ -92,6 +92,9 @@ class AbstractTraceIngest:
 
     # update event data with things like ts-offset or ts-scaling
     def updated_event(self, event: TraceEvent) -> TraceEvent:
+        if event["ph"] not in "XBE":
+            return event
+
         if "ts" in event:
             event["ts"] *= self.scale
         if "dur" in event:
@@ -99,10 +102,17 @@ class AbstractTraceIngest:
         if self.rank_pid >= 0:
             event["pid"] = self.rank_pid
 
+        the_args = "args"
+        if "attr" in event:
+            the_args = "attr"
+        if the_args not in event:
+            event[the_args] = {}
+
         # make sure the pid/tid entries are numbers
         try:
             event["pid"] = int(event["pid"])
         except ValueError:
+            event[the_args]["opid"] = event["pid"]
             event["pid"] = hash(event["pid"])
         except KeyError:
             aiulog.log(aiulog.WARN, "Imported event has no PID!!! Setting -1", event)
@@ -112,15 +122,11 @@ class AbstractTraceIngest:
             try:
                 event["tid"] = int(event["tid"])
             except ValueError:
+                event[the_args]["otid"] = event["tid"]
                 event["tid"] = hash(event["tid"])
 
-        if event["ph"] not in ["F", "f", "s", "t", "C"]:
-            if "args" in event:
-                event["args"]["jobhash"] = self.jobhash
-            elif "attr" in event:
-                event["attr"]["jobhash"] = self.jobhash
-            else:
-                event["args"] = {"jobhash": self.jobhash}
+        if event["ph"] not in ["F", "f", "s", "t", "C", "M"]:
+            event[the_args]["jobhash"] = self.jobhash
         return event
 
 
@@ -199,7 +205,7 @@ class JsonEventTraceIngest(AbstractTraceIngest):
     def build_complete_event(self) -> TraceEvent:
         def _torch_prof_or_none(name, evtype) -> TraceEvent:
             if evtype == "M":
-                return None
+                return event
             elif "PyTorch Profiler" not in name:
                 return event
             else:

--- a/src/aiu_trace_analyzer/pipeline/inverse_ts.py
+++ b/src/aiu_trace_analyzer/pipeline/inverse_ts.py
@@ -91,6 +91,9 @@ class InversedTSDetectionContext(AbstractContext):
 # uses InversedTSDetectionContext to hold B- or E-events until their counterpart is appears
 # and checks timestamps are ordered before emitting them in the B -> E order
 def drop_timestamp_reversed_events(event: TraceEvent, context: AbstractContext) -> list[TraceEvent]:
+    return [event]
+
+    # current ingestion will create complete events, so this is no longer needed
     assert( isinstance(context, InversedTSDetectionContext) )
 
     event_list = []

--- a/src/aiu_trace_analyzer/pipeline/normalize.py
+++ b/src/aiu_trace_analyzer/pipeline/normalize.py
@@ -116,7 +116,7 @@ def _attr_to_args(event: TraceEvent) -> TraceEvent:
         if "args" not in event:
             event["args"] = copy.deepcopy({})
         for k,v in event["attr"].items():
-            event["args"][k] = event["attr"][k]
+            event["args"][k] = copy.deepcopy( v )
         event.pop("attr")
     return event
 
@@ -125,10 +125,10 @@ def _hex_to_int_str(event: TraceEvent) -> TraceEvent:
         if not isinstance(event["args"], dict):
             return event
 
-        for k, v in event["args"].items():
-            if isinstance(v, str):
+        for k in ["TS1", "TS2", "TS3", "TS4", "TS5", "Power"]:
+            if k in event["args"] and isinstance(event["args"][k], str):
                 try:
-                    event["args"][k] = str(int(v,0))
+                    event["args"][k] = str(int(event["args"][k], 0))
                 except ValueError:
                     pass # do nothing and leave the value alone
     return event
@@ -151,7 +151,7 @@ def normalize_phase1(event: TraceEvent, context: AbstractContext) -> list[TraceE
 
     # don't let anything pass that's not in X-event
     if event["ph"] not in ["X"]:
-        return []
+        return [ event ]
 
     event = _attr_to_args(event)
     event = _hex_to_int_str(event)
@@ -170,7 +170,7 @@ def normalize_phase2(event: TraceEvent, context: AbstractContext) -> list[TraceE
 
     # don't let anything pass that's not in X-event
     if event["ph"] not in ["X"]:
-        return []
+        return [ event ]
 
     if "args" in event and "TS1" in event["args"]:
         qid = context.queue_hash(event)

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -441,7 +441,7 @@ def compute_utilization(event: TraceEvent, context: AbstractContext) -> list[Tra
         cmpt_dur = float(event["dur"])
         utilization = abs(ideal_dur/cmpt_dur)
 
-        if utilization > 0:
+        if utilization > 0.0:
             event["args"]["core used"] = True
 
         if utilization > 1.0:   # warning about >100% utilization

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -290,7 +290,7 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
     def accumulate_categories(self, pid, kernel, ideal_dur, duration):
         if kernel not in self.kernel_cat_map:
             self.other_warning += 1
-            aiulog.log(aiulog.INFO, "UTL:", pid, "Unexpected kernel name: ", kernel, "Accounting for as 'other'.")
+            aiulog.log(aiulog.DEBUG, "UTL:", pid, "Unexpected kernel name: ", kernel, "Accounting for as 'other'.")
             kernel = "other"
 
         cat = self.kernel_cat_map[kernel]
@@ -451,7 +451,10 @@ def compute_utilization(event: TraceEvent, context: AbstractContext) -> list[Tra
             context.warn_util_100 += 1
             utilization = 1.0
 
-        event["cat"] = context.accumulate_categories(pid, kernel_name, ideal_dur, cmpt_dur)
+        if "cat" in event:
+            event["args"]["user_cat"] = context.accumulate_categories(pid, kernel_name, ideal_dur, cmpt_dur)
+        else:
+            event["cat"] = context.accumulate_categories(pid, kernel_name, ideal_dur, cmpt_dur)
         util_counter = context.make_utilization_event(event, utilization*100.0)
         return [event] + util_counter
 

--- a/src/aiu_trace_analyzer/pipeline/tb_refinement.py
+++ b/src/aiu_trace_analyzer/pipeline/tb_refinement.py
@@ -105,7 +105,6 @@ class RefinementContext(AbstractHashQueueContext):
         assert new_name != "", f"Event Name treatment created an empty name from event:'{event["name"]}'."
         event["name"] = new_name
 
-
         event = self._update_for_collective(event)
         return event
 
@@ -145,8 +144,9 @@ class RefinementContext(AbstractHashQueueContext):
             # and 'name' for communication tb calculation
             if "args" in event and Coll_data_size in event["args"] and AllReduce in event["name"]:
                 event["cat"] = event["cat"] if "cat" in event else "user_annotation"
+                event["args"]["orig_name"] = event["name"]
                 event["name"] = "gloo:all_reduce"
-                event["external id"] = event["args"].pop("fn_idx")
+                event["external id"] = re.search(r"_(\d+)", event["args"]["orig_name"]).group(1)
             else:
                 event["cat"] = event["cat"] if "cat" in event else "cpu_op"
             return event

--- a/src/aiu_trace_analyzer/pipeline/tb_refinement.py
+++ b/src/aiu_trace_analyzer/pipeline/tb_refinement.py
@@ -1,6 +1,7 @@
 # Copyright 2024-2025 IBM Corporation
 
 import re
+import copy
 
 from aiu_trace_analyzer.types import InputDialectTORCH, GlobalIngestData
 import aiu_trace_analyzer.logger as aiulog
@@ -19,13 +20,14 @@ AllReduce = "AllReduce_all_reduce"
 
 
 class RefinementContext(AbstractHashQueueContext):
-    name_converter = re.compile(r"^([^-\[]+_)(\d+)")
+    name_converter = re.compile(r"([\D\[\]-]+)(\d+)")
 
-    def __init__(self, exporter: output.AbstractTraceExporter) -> None:
+    def __init__(self, exporter: output.AbstractTraceExporter, keep_names: bool = False) -> None:
         super().__init__()
         self.exporter = exporter
         self.meta_exported = False
         self.has_coll_bw = False
+        self.keep_names = keep_names
         self.dialect = InputDialectTORCH()
 
     def drain(self) -> list[TraceEvent]:
@@ -71,22 +73,40 @@ class RefinementContext(AbstractHashQueueContext):
         self.meta_exported = True
         return revents
 
-    def update_event_data_heavy(self, event) -> TraceEvent:
-        pid = event["pid"]
+    def _update_event_names(self, ev_name: str) -> tuple[str, bool]:
+        if self.keep_names:
+            return ev_name, False
 
-        # to group function calls by name without index...
-        # ...extract a function index (if any) from the event name
-        match = self.name_converter.search(event["name"])
-        if match and "args" in event:
-            event["args"]["fn_idx"] = match.group(2)
-        # ...and replace it with _[N]
-            event["name"] = re.sub(self.name_converter, f"{match.group(1)}[N]", event["name"], count=1)
+        new_name = ""
+        last_idx = 0
+        for match in self.name_converter.finditer(ev_name):
+            new_name += re.sub("_$", "", match.group(1))
+            if match.group(1).endswith("V"):
+                new_name += match.group(2)
+            last_idx = match.end()
 
+        new_name += ev_name[last_idx:]
+        return new_name, last_idx > 0
+
+    def _update_for_collective(self, event: TraceEvent) -> TraceEvent:
         if "coll" in str(event["tid"]):
             event["tid"] = 10000+int(str(event["tid"])[4])
 
         # ensure events with different PIDs have different TIDs
-        event["tid"] = pid*100000 + event["tid"]
+        event["tid"] = event["pid"]*100000 + event["tid"]
+        return event
+
+    def update_event_data_heavy(self, event: TraceEvent) -> TraceEvent:
+        if not PipelineContextTool.is_acc_event(event):
+            return event
+        (new_name, changed) = self._update_event_names(event["name"])
+        if changed:
+            event["args"]["orig_name"] = event["name"]
+        assert new_name != "", f"Event Name treatment created an empty name from event:'{event["name"]}'."
+        event["name"] = new_name
+
+
+        event = self._update_for_collective(event)
         return event
 
     def _queue_add_device(self, pid, ts, is_acc: bool = True):
@@ -140,8 +160,7 @@ class RefinementContext(AbstractHashQueueContext):
                     return hash(pid) % 10000 + 10000
             return pid
 
-        if "args" in event and "jobhash" in event["args"]:
-            self.dialect = GlobalIngestData.get_dialect(event["args"]["jobhash"])
+        self.dialect = GlobalIngestData.get_dialect(event["args"]["jobhash"])
 
         if self.dialect.get("NAME") == "TORCH":
             if "opid" in event["args"]:

--- a/src/aiu_trace_analyzer/pipeline/tb_refinement.py
+++ b/src/aiu_trace_analyzer/pipeline/tb_refinement.py
@@ -143,6 +143,15 @@ class RefinementContext(AbstractHashQueueContext):
         if "args" in event and "jobhash" in event["args"]:
             self.dialect = GlobalIngestData.get_dialect(event["args"]["jobhash"])
 
+        if self.dialect.get("NAME") == "TORCH":
+            if "opid" in event["args"]:
+                event["pid"] = event["args"]["opid"]
+                event["args"].pop("opid")
+            if "otid" in event["args"]:
+                event["tid"] = event["args"]["otid"]
+                event["args"].pop("otid")
+            return event
+
         pid = _resolve_string_pids(event["pid"])
 
         if PipelineContextTool.is_acc_event(event):

--- a/tests/aiu_trace_analyzer/pipeline/test_tb_refinement.py
+++ b/tests/aiu_trace_analyzer/pipeline/test_tb_refinement.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from aiu_trace_analyzer.types import TraceEvent
+from aiu_trace_analyzer.types import TraceEvent, GlobalIngestData, InputDialectFLEX
 from aiu_trace_analyzer.export.exporter import JsonFileTraceExporter
 from aiu_trace_analyzer.pipeline.hashqueue import AbstractHashQueueContext
 from aiu_trace_analyzer.pipeline.tb_refinement import RefinementContext
@@ -13,36 +13,42 @@ def tb_ctx(tmp_path):
     exporter = JsonFileTraceExporter(f'{tmp_path}/tb_test_out.json')
     return RefinementContext(exporter)
 
+@pytest.fixture
+def global_ingest_data():
+    jobdata = GlobalIngestData.add_job_info(source_uri="tb_test_frame.json", data_dialect=InputDialectFLEX())
+    return jobdata
+
 
 
 list_events_test_heavy = [
     # regular, simple case for fn-idx removal
-    ({"name":"event_123", "pid": 1, "tid": 1, "args": {}},
-     {"name":"event_[N]", "pid": 1, "tid": 1, "args": {"fn_idx": "123"}}),
+    ({"name":"event_123", "pid": 1, "tid": 1, "cat": "kernel", "args": {"TS1": 12345}},
+     {"name":"event", "pid": 1, "tid": 1, "args": {"orig_name": "event_123"}}),
 
     # testing for only replacing the first index and keep the rest
-    ({"name":"event_123[sync=sgroup_0_s2_321]", "pid": 1, "tid": 1, "args": {}},
-     {"name":"event_[N][sync=sgroup_0_s2_321]", "pid": 1, "tid": 1, "args": {"fn_idx": "123"}} ),
+    ({"name":"event_123[sync=sgroup_0_s2_321]", "pid": 1, "tid": 1, "args": {"TS1": 12345}},
+     {"name":"event[sync=sgroup_s]", "pid": 1, "tid": 1, "args": {"orig_name": "event_123[sync=sgroup_0_s2_321]"}} ),
 
     # testing existing fn_idx will be overwritten if it already exists
-    ({"name":"event_123", "pid": 1, "tid": 1, "args": {"fn_idx": "321"}},
-     {"name":"event_[N]", "pid": 1, "tid": 1, "args": {"fn_idx": "123"}}),
+    ({"name":"event_123", "pid": 1, "tid": 1, "args": {"TS1": 12345, "orig_name": "event_321"}},
+     {"name":"event", "pid": 1, "tid": 1, "args": {"orig_name": "event_123"}}),
 
     # testing with event name without idx
-    ({"name":"eventname", "pid": 1, "tid": 1, "args": {}},
+    ({"name":"eventname", "pid": 1, "tid": 1, "args": {"TS1": 12345}},
      {"name":"eventname", "pid": 1, "tid": 1, "args": {}}),
 
     # testing not adding new items if nothing to do
-    ({"name":"eventname", "pid": 1, "tid": 1},
-     {"name":"eventname", "pid": 1, "tid": 1}),
+    ({"name":"eventname", "pid": 1, "tid": 1, "args": {}},
+     {"name":"eventname", "pid": 1, "tid": 1, "args": {}}),
 
     # testing the coll-tid replacement
     ({"name":"event_123", "pid": 1, "tid": "coll1", "args": {}},
-     {"name":"event_[N]", "pid": 1, "tid": 10001, "args": {"fn_idx": "123"}}),
+     {"name":"event_123", "pid": 1, "tid": 10001, "args": {}}),
 ]
 
 @pytest.mark.parametrize('event_in, reference', list_events_test_heavy)
-def test_tb_refinement_heavy(event_in: TraceEvent, reference: TraceEvent, tb_ctx):
+def test_tb_refinement_heavy(event_in: TraceEvent, reference: TraceEvent, tb_ctx, global_ingest_data):
+    event_in["args"]["jobhash"] = global_ingest_data   # need to artificially add jobinfo hash to allow dialect-based detection of accellerator events
     result = tb_ctx.update_event_data_heavy(event_in)
 
     assert result["name"] == reference["name"]
@@ -51,8 +57,8 @@ def test_tb_refinement_heavy(event_in: TraceEvent, reference: TraceEvent, tb_ctx
         assert "args" not in result
     else:
         assert "args" in result
-        if "fn_idx" in reference["args"]:
-            assert "fn_idx" in result["args"]
-            assert result["args"]["fn_idx"] == reference["args"]["fn_idx"]
+        if "orig_name" in reference["args"]:
+            assert "orig_name" in result["args"]
+            assert result["args"]["orig_name"] == reference["args"]["orig_name"]
         else:
-            assert "fn_idx" not in result["args"]
+            assert "orig_name" not in result["args"]


### PR DESCRIPTION
This is a review of how to handle several types of events and how to deal with names and their aggregation for integration with TensorBoard.

Sorry for more changes than I'd want for a PR, here are the highlights:
 * with `--tb`: strip almost all numbers from core event names to allow aggregation, the orig_name is moved into args
 * new cmdline option `--keep_names` to disable the name-change in the above case
 * allow meta `M`-events to pass through the pipeline (reduce the mess-up of torch profile data)
 * several updates to reduce the mess-up of torch profile data (pids, category entries, etc)
 * updated tests
