### PR TITLE
fix for disabling/omitting stages in profiles

### DIFF
--- a/src/aiu_trace_analyzer/core/stage_profile.py
+++ b/src/aiu_trace_analyzer/core/stage_profile.py
@@ -55,6 +55,6 @@ class StageProfileChecker:
     def fwd_find_stage(self, stage: str) -> bool:
         for incr, st in enumerate(self.stages.profile[self.reg_idx:]):
             if stage == st[0]:
-                self.reg_idx += incr
+                self.reg_idx += incr + 1
                 return st[1]
         return False

--- a/src/aiu_trace_analyzer/core/stage_profile.py
+++ b/src/aiu_trace_analyzer/core/stage_profile.py
@@ -3,6 +3,7 @@
 import json
 import os
 from pathlib import Path
+from copy import deepcopy
 
 import aiu_trace_analyzer.logger as aiulog
 
@@ -21,7 +22,7 @@ class StageProfile:
 
         # if a profile is empty, then assume all stages to be enabled
         if len(profile_data) == 0:
-            profile_data = all_stages
+            profile_data = deepcopy(all_stages)
 
         profile = StageProfile(profile_data, all_stages)
         return profile

--- a/src/aiu_trace_analyzer/core/stage_profile.py
+++ b/src/aiu_trace_analyzer/core/stage_profile.py
@@ -4,35 +4,45 @@ import json
 import os
 from pathlib import Path
 
+import aiu_trace_analyzer.logger as aiulog
 
 class StageProfile:
     _everything_profile = os.path.join(os.path.dirname(__file__), "../profiles/everything.json")
 
-    def __init__(self, profile_data: dict):
-        self.profile = self._ingest_profile_data(profile_data)
+    def __init__(self, profile_data: dict, all_stages: dict):
+        self.profile = self._ingest_profile_data(profile_data, all_stages)
 
     @classmethod
     def from_json(cls, file: Path):
         with open(file, 'r') as config_fd:
             profile_data = json.load(config_fd)
+        with open(cls._everything_profile, 'r') as all_fd:
+            all_stages = json.load(all_fd)
 
         # if a profile is empty, then assume all stages to be enabled
         if len(profile_data) == 0:
-            with open(StageProfile._everything_profile, 'r') as config_fd:
-                profile_data = json.load(config_fd)
+            profile_data = all_stages
 
-        profile = StageProfile(profile_data)
+        profile = StageProfile(profile_data, all_stages)
         return profile
 
-    def _ingest_profile_data(self, profile_data: dict) -> list[str]:
+    def _ingest_profile_data(self, profile_data: dict, all_stages: dict) -> list[str]:
         if 'stages' not in profile_data:
             raise KeyError("Profile data is missing 'stages' key.")
 
-        profile = []
-        for stage_data in profile_data['stages']:
+        # walk the full list and pick up the enabled/disabled flag from the requested config
+        next_stage, next_enabled = profile_data['stages'].pop(0).popitem()
+        profile: list[tuple[str, bool]] = []
+        for stage_data in all_stages['stages']:
             stage, enabled = stage_data.popitem()
-            if enabled:
-                profile.append(stage)
+            if not enabled:
+                aiulog.log(aiulog.WARN, "STP: all-stages profile has unexpectedly disabled stage: ", stage)
+            if next_stage == stage:
+                profile.append((stage, next_enabled))
+                next_stage, next_enabled = profile_data['stages'].pop(0).popitem() if len(profile_data['stages']) > 0 else ("nothing", False)
+            else:
+                profile.append((stage, False))
+            aiulog.log(aiulog.DEBUG, "PRF:", stage, profile[-1][1])
         return profile
 
 
@@ -43,7 +53,7 @@ class StageProfileChecker:
 
     def fwd_find_stage(self, stage: str) -> bool:
         for incr, st in enumerate(self.stages.profile[self.reg_idx:]):
-            if stage == st:
+            if stage == st[0]:
                 self.reg_idx += incr
-                return True
+                return st[1]
         return False

--- a/tests/aiu_trace_analyzer/core/test_stage_profile.py
+++ b/tests/aiu_trace_analyzer/core/test_stage_profile.py
@@ -35,7 +35,7 @@ def test_default_is_everything(default_profile_config, everything_profile):
 
 
 def test_fwd_find(default_stage_checker):
-    test_stages = [('create_slice_from_BE', True, 1), ('do_not_move_index', False, 1), ('pipeline_barrier', True, 4)]
+    test_stages = [('create_slice_from_BE', True, 2), ('do_not_move_index', False, 2), ('pipeline_barrier', True, 5)]
 
     assert isinstance(default_stage_checker, StageProfileChecker)
 


### PR DESCRIPTION
PR addresses issue #32 

Previously, only enabled stages were kept as a list. The new method, first creates a list of enabled/disabled stages based on the full list and then uses that info to deal with optional (cmdline-enabled/disabled) stages.