### PR TITLE
leave pids untouched for multi-aiu pytorch traces

### DIFF
--- a/src/aiu_trace_analyzer/ingest/ingestion.py
+++ b/src/aiu_trace_analyzer/ingest/ingestion.py
@@ -99,7 +99,8 @@ class AbstractTraceIngest:
             event["ts"] *= self.scale
         if "dur" in event:
             event["dur"] = float(event["dur"] * self.scale)
-        if self.rank_pid >= 0:
+        dialect = GlobalIngestData.get_dialect(self.jobhash)
+        if self.rank_pid >= 0 and not isinstance(dialect, InputDialectTORCH):
             event["pid"] = self.rank_pid
 
         the_args = "args"


### PR DESCRIPTION
For multi-AIU traces, Acelyzer sets the PID to be the rank ID. This is not currently needed for PyTorch Profiler traces as TensorBoard handles each rank individually and thus overlapping PIDs across ranks is fine for now.

We should leave the PIDs as is from PyTorch Profiler because otherwise the metadata for assigning thread names and sorting order is out of sync which messes with the trace view.

Before fix:
<img width="1592" height="308" alt="image" src="https://github.com/user-attachments/assets/07d7654d-4529-4544-92b0-12092ea682b2" />

After fix:
<img width="1592" height="308" alt="image" src="https://github.com/user-attachments/assets/18864806-d7b2-4f9f-8725-78d176a18b77" />
