### PR TITLE
fix shift overlap resolution

### DIFF
--- a/src/aiu_trace_analyzer/pipeline/overlap.py
+++ b/src/aiu_trace_analyzer/pipeline/overlap.py
@@ -131,13 +131,19 @@ class OverlapDetectionContext(EventPairDetectionContext):
                 oevent["ts"] += round(ts_shift+0.0015, 3)  # round-up the required ts-shift and add 1ns
                 if ts_shift > oevent["dur"]:
                     aiulog.log(aiulog.WARN, "Overlap shifting of", oevent["name"], "exceeds its duration", oevent["dur"])
+                else:
+                    oevent["args"]["orig_dur"] = oevent["dur"]
+                    oevent["dur"] -= round(ts_shift+0.0015, 3) # reduce the duration to keep the end-time unchanged
+                # feed offending event back into the detector to make sure it's end time does not collide with anything else
+                rlist = self.overlap_detection(oevent)
             else:
                 aiulog.log(aiulog.WARN, "Detected overlap of", oevent["name"], "exceeds the threshold/limit",
                            self.ts_shift_threshold, "us. Overlap of", ts_shift,
                            "us: increase threshold or use different overlap res option.")
+                rlist = [oevent]
 
             self.resolved += 1
-            return [oevent]
+            return rlist
         elif self.overlap_resolve == self.OVERLAP_RESOLVE_TID:
             oevent["tid"] += 1
             # feed offending event back into the detector with the new TID to make sure there are no collisions there either


### PR DESCRIPTION
Fixes 2 things for the `--overlap shift` option:

1. Shift only the start timestamp and not the end timestamp
2. Recheck for overlap after the shift
   1. There shouldn't be overlap detected at this stage, but we must still pass it through `overlap_detection` so that it is added to the queue of events on the thread
   2. Before this fix, sequential overlapping events were missed
   
   
<img width="862" height="149" alt="image" src="https://github.com/user-attachments/assets/77cb8d22-5e32-4e4d-bd42-038f83d3f2d0" />

```
E0930 09:57:01.622956 8504937472 op_tree.py:136] Error in input data: ranges on the same thread should not intersect!Father:(aiuCreateVirtualAddresses,7156384389863.012,7156384389864.277) Child:(aiuLaunchScheduleCompute,7156384389864.274,7156384394097.811)
```

