### PR TITLE
metadata passthrough: collect at ingestion and pass to export

### DIFF
--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -151,6 +151,7 @@ class Acelyzer:
             else:
                 self.exporter = output.ProtobufTraceExporter(target_uri=self.args.output,
                                                              settings=vars(self.args))
+        self.exporter.export_meta(importer.get_passthrough_meta())
 
         self.register_processing_functions(process, self.args, self.exporter)
 

--- a/src/aiu_trace_analyzer/trace_view.py
+++ b/src/aiu_trace_analyzer/trace_view.py
@@ -20,6 +20,7 @@ class TraceView(object):
         self.stack_frames = dict(stack_frames)
         self.samples = list(samples)
         self.device_data = []
+        self.meta_data = {}
 
     def append_trace_event(self, trace_event):
 
@@ -44,6 +45,9 @@ class TraceView(object):
         for d in data:
             self.device_data.append(d)
 
+    def add_metadata(self, meta: dict):
+        self.meta_data.update(meta)
+
     def dump(self, fp=None) -> str:
         """
         trace event json format:
@@ -61,7 +65,6 @@ class TraceView(object):
            "samples": [...],
         }
         """
-
         dic = {
             "deviceProperties": self.device_data,
             "traceName": self.other_data["Settings"]["output"],
@@ -72,6 +75,7 @@ class TraceView(object):
             # "stackFrames": self.stack_frames,
             # "samples": self.samples,
         }
+        dic.update(self.meta_data)
 
         if fp:
             json.dump(dic, fp, indent=4)


### PR DESCRIPTION
Some/most of the metadata from Torch profiles didn't make it into the output file. This PR is an attempt to solve this by collecting any json data that's not needed for processing and passing it to the exporter to dump it into the output file.

As long as there's a single input file, this is a straight-forward process. However, if multiple input files are ingested, the idea is to collect all data and merge it via `dict.update()`. If more sophisticated methods of merging are needed, we can address them in a subsequent PR.