### PR TITLE
don't recursively search for files automatically

### DIFF
--- a/src/aiu_trace_analyzer/ingest/ingestion.py
+++ b/src/aiu_trace_analyzer/ingest/ingestion.py
@@ -510,6 +510,6 @@ class MultifileIngest(AbstractTraceIngest):
                 continue
             subdir, fpat = '/'.join(expanded.split('/')[:-1]), expanded.split('/')[-1]
             aiulog.log(aiulog.DEBUG, "Opening path:", pathlib.Path(subdir), "Pattern:", fpat)
-            flist += [f'{x}' for x in list(pathlib.Path(subdir).rglob(fpat))]
-        aiulog.log(aiulog.INFO, "Reading files:", fpat_list)
+            flist += [f'{x}' for x in list(pathlib.Path(subdir).glob(fpat))]
+        aiulog.log(aiulog.INFO, "Reading files:", flist)
         return flist


### PR DESCRIPTION
We were previously searching all subdirectories of the provided filepath when we should only do so if a pattern like `**/` is explicitly passed to Acelyzer.

See: https://docs.python.org/3/library/pathlib.html#pathlib.Path.rglob