### PR TITLE
use proper 3way version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiu_trace_analyzer"
-version = "1.0"
+version = "1.0.0"
 authors = [
     { name="Lars Schneidenbach et. al" },
 ]


### PR DESCRIPTION
I guess, we should use `1.0.0` and not just `1.0`... :facepalm: 