### PR TITLE
Correct Power Unit Scaling Issue

### DIFF
--- a/src/aiu_trace_analyzer/pipeline/power.py
+++ b/src/aiu_trace_analyzer/pipeline/power.py
@@ -116,13 +116,13 @@ class PowerExtractionContext(AbstractHashQueueContext):
             new_val = round((new_val / (this[TS_CYCLE_KEY] - prev[TS_CYCLE_KEY])), 3)
 
         elif self.power_ts == 4:
-            dt_in_ns = (this[TS_CYCLE_KEY] - prev[TS_CYCLE_KEY]) * 1000  # nano-second
+            dt_in_us = (this[TS_CYCLE_KEY] - prev[TS_CYCLE_KEY])  # micro-second
             # Least significant bit for the Analog-2-Digital Converter (LSB=1/512 from snt_dpm_dcr: Register-ro)
-            LSB_on_ADC = 5.37 / 512
+            LSB_on_ADC = 1 / 512
             voltage = 12            # volt/s
 
             # dcharge is sum(current), has to be in nano-Ampere to get Power in Watts
-            new_val = voltage * new_val * LSB_on_ADC / dt_in_ns
+            new_val = voltage * new_val * LSB_on_ADC / dt_in_us
             if new_val > 100:
                 aiulog.log(aiulog.DEBUG, "POWER: BAD event a,b: ", new_val, prev, this)
                 self.bad_events += 1


### PR DESCRIPTION
This PR addresses the unit scaling issue in power calculation within `src/aiu_trace_analyzer/pipeline/power.py` by implementing two main corrections:

1.  **Time Unit Correction (Line 119):** The change in time (`dt`) is adjusted from an implicit nanosecond (`ns`) to the correct microsecond (`ms`) unit. This is necessary for consistency with the DPM definition where the `q_card_12v` value implies an `LSB_on_ADC` of $1/512$ $\mu\text{coulomb}$.

2.  **LSB Value Correction (Line 121):** The value of `LSB_on_ADC` is corrected from `5.37 / 512` to `1 / 512` to accurately match the actual DPM register definition.

### Corrected Power Calculation Formula:
```
Power in Watts = (Voltage * delta_q * LSB_on_ADC) / dt_in_us 
Power in Watts = (12V * delta_q * (1 / 512)) / (this_ts4 - prev_ts4)
```

### Important Note (Disclaimer):

These changes resolve the unit scaling discrepancy. The current power readouts effectively **excludes** the baseline "idle power" of the device, focusing instead on the power consumed by the workload during the computed energy difference.

The fundamental reason for this interpretation is that the calculation is based on the *delta* in energy consumption ($\Delta E$) over the time interval ($\Delta t$), which yields an instantaneous power value (in Watts).