### PR TITLE
remove warning if event-filter is empty

### DIFF
--- a/src/aiu_trace_analyzer/pipeline/normalize.py
+++ b/src/aiu_trace_analyzer/pipeline/normalize.py
@@ -116,6 +116,8 @@ class NormalizationContext(AbstractHashQueueContext):
 
     def extract_eventfilters(self, filterstr: str) -> dict[str, re.Pattern]:
         event_filters: dict[str, re.Pattern] = {}
+        if len(filterstr.strip()) == 0:
+            return event_filters
         for fstr in filterstr.split(","):
             key_regex = fstr.split(":")
             if len(key_regex) != 2:


### PR DESCRIPTION
event filter step prints an unnecessary warning if no event filtering was requested.
This PR adds a check to skip event filter processing/warning if the input filter-string is empty.