### PR TITLE
src/aiu_trace_analyzer/pipeline/rcu_utilization.py: resolve ZeroDivisionError

### DIFF
--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -487,7 +487,7 @@ def compute_utilization(event: TraceEvent, context: AbstractContext) -> list[Tra
 
         # cmpt_dur = int(event["args"]["TS4"]) - int(event["args"]["TS3"])
         cmpt_dur = float(event["dur"])
-        utilization = abs(ideal_dur/cmpt_dur)
+        utilization = abs(ideal_dur/cmpt_dur) if cmpt_dur != 0 else 0.0
 
         if utilization > 0.0:
             event["args"]["core used"] = True


### PR DESCRIPTION
Duration of some kernel events are zero
```
logs/roberta/1515203e6958_55547.1762519496389643476.pt.trace.json:94321:    "ts": 3219399669390.668, "dur": 0.000, 

  {
    "ph": "X", "cat": "kernel", "name": "ClearScratchad-Internal", "pid": 0, "tid": 1,
    "ts": 3219399669390.668, "dur": 0.000,
    "args": {
      "context": "39932", "stream": 1, "correlation": 4162, "device": 0, "submitted": 1757917343133882969, "queued": 1762519473669359609
    }
  },
 
```
So acelyzer was throwing error
```
  File "/usr/local/lib/python3.12/site-packages/aiu_trace_analyzer/pipeline/rcu_utilization.py", line 490, in compute_utilization
    utilization = abs(ideal_dur/cmpt_dur)
                      ~~~~~~~~~^~~~~~~~~
ZeroDivisionError: float division by zero
```