### PR TITLE
TID-based overlap detection with dynamic range

### DIFF
--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -485,8 +485,12 @@ class Acelyzer:
         process.register_stage(callback=event_pipe.assert_ts_sequence, context=monotonic_ts_ctx_a)
 
         # register pre-processing: resolve overlap conflicts caused by partially overlapping slices
-        overlap_ctx = event_pipe.OverlapDetectionContext(overlap_resolve=self._overlap_option_from_arg(args.overlap),
+        overlap_arg = self._overlap_option_from_arg(args.overlap)
+        overlap_ctx = event_pipe.OverlapDetectionContext(overlap_resolve=overlap_arg,
                                                          ts_shift_threshold=self.defaults["ts_shift_threshold"])
+        if overlap_arg == event_pipe.OverlapDetectionContext.OVERLAP_RESOLVE_TID:
+            process.register_stage(callback=event_pipe.detect_partial_overlap_tids, context=overlap_ctx)
+            process.register_stage(callback=event_pipe.pipeline_barrier, context=event_pipe._main_barrier_context)
         process.register_stage(callback=event_pipe.detect_partial_overlap_events, context=overlap_ctx)
 
         # validate that the overlap has not messed up the event stream ordering

--- a/src/aiu_trace_analyzer/pipeline/__init__.py
+++ b/src/aiu_trace_analyzer/pipeline/__init__.py
@@ -59,6 +59,7 @@ from aiu_trace_analyzer.pipeline.mappings import map_complete_to_duration, remov
 from aiu_trace_analyzer.pipeline.normalize import normalize_phase1, normalize_phase2
 from aiu_trace_analyzer.pipeline.correctness import event_sanity_checks
 from aiu_trace_analyzer.pipeline.overlap import (
+    detect_partial_overlap_tids,
     detect_partial_overlap_events,
     assert_ts_sequence,
     assert_global_ts_sequence,

--- a/src/aiu_trace_analyzer/profiles/everything.json
+++ b/src/aiu_trace_analyzer/profiles/everything.json
@@ -23,6 +23,8 @@
         {"recombine_cpu_events": true},
         {"sort_events": true},
         {"assert_ts_sequence": true},
+        {"detect_partial_overlap_tids": true},
+        {"pipeline_barrier": true},
         {"detect_partial_overlap_events": true},
         {"assert_ts_sequence": true},
         {"collect_iteration_stats": true},

--- a/src/aiu_trace_analyzer/profiles/torch_minimal.json
+++ b/src/aiu_trace_analyzer/profiles/torch_minimal.json
@@ -23,6 +23,8 @@
         {"recombine_cpu_events": false},
         {"sort_events": true},
         {"assert_ts_sequence": false},
+        {"detect_partial_overlap_tids": true},
+        {"pipeline_barrier": true},
         {"detect_partial_overlap_events": true},
         {"assert_ts_sequence": true},
         {"collect_iteration_stats": true},


### PR DESCRIPTION
We've encountered traces where thread ids occupy subsequent numbers (nothing unusual). If event overlap is detected in one tid and the subsequent tid is already in use, it can cause collisions, crashes and all kinds of weird behavior.

This PR extends the overlap treatment by adding a scanning stage to collect all tids with input events and then creates a mapping from existing to available tids for overlap resolution.