### PR TITLE
Update python-app.yml: enforce code formatting rules

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        # flake8 returns non-zero when identifies format issues
         flake8 . --count --config=./.flake8 --statistics
     - name: Test with pytest
       run: |


### PR DESCRIPTION
Existing GH action is checking code format with flake8, but any reports are just warnings. We should enforce that format to avoid anyone with a pre-commit hook having to fix other peoples formatting.