### PR TITLE
feat: replace hardcoded __version__ with git-tag-based versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -40,5 +40,4 @@ packages = {find = {where = ["src"]}}
 [tool.setuptools.package-data]
 aiu_trace_analyzer = ["profiles/*"]
 
-[tool.setuptools.dynamic]
-version = {attr = "aiu_trace_analyzer.__version__"}
+[tool.setuptools_scm]

--- a/src/aiu_trace_analyzer/__init__.py
+++ b/src/aiu_trace_analyzer/__init__.py
@@ -1,6 +1,10 @@
 # Copyright 2024-2025 IBM Corporation
 
-__version__ = "1.0.2"
+try:
+    from importlib.metadata import version, PackageNotFoundError
+    __version__ = version("aiu_trace_analyzer")
+except PackageNotFoundError:
+    __version__ = "unknown"
 
 from aiu_trace_analyzer.trace_view import AbstractEventType
 from aiu_trace_analyzer import *


### PR DESCRIPTION
Fixes #45

## Description

The version number in this package was hardcoded as a string in `src/aiu_trace_analyzer/__init__.py`. This means every release requires a manual commit to bump it, which is error-prone and easy to forget.

This PR switches to git-tag-based versioning using setuptools-scm. The version is now derived automatically from the current git tag. If the package is installed from a checkout that is not on a tagged commit, the version will include a dev suffix. If the package is not installed at all, it falls back to "unknown".

## Changes Made

- `pyproject.toml`: added setuptools-scm>=8 to build requirements and added an empty [tool.setuptools_scm] section to activate git-tag versioning
- `src/aiu_trace_analyzer/__init__.py`: replaced `__version__ = "1.0.2"` with an importlib.metadata lookup that reads the version from the installed package metadata

## How Was This Tested?

- [x] Manual Verification: Confirmed the package still imports correctly and __version__ resolves to the expected value when installed.

## AI Usage Disclosure

- [x] No AI used.