### PR TITLE
Fix rcu utilization for tspyre stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ The `-c` argument provides the tool with the log file which is being processed f
 acelyzer -i "${TRACE_DIR}/hap-json-files/hap-bs8-seq256-autopilot-0-34707-job-*.json" -c ${TRACE_GIT}/hap-json-files/hap-bs8-seq256-autopilot-0.log -o hap_trace.json
 ```
 
+*NOTE*
+For getting the utilization in the torch spyre stack, you should specify the path to the inductor cache directory after `-c`. By default, this path is `/tmp/torchinductor_<sanitized_username>`. For e.g., if the sanitized username is xyz, you need to run:
+```
+acelyzer -i <Path to trace file json> -c /tmp/torchinductor_xyz
+```
+In case, you used a different cache dir path by setting TORCHINDUCTOR_CACHE_DIR environment variable for your workload, you need to specify the same path after `-c`.
+
+
 An evolving feature is the use of processing profiles (option `-P`) to allow control which processing stages are enabled. By default, the `everything.json` profile (or `default.json`) is used. Note that the cmdline still overrides the deactivation of stages so that if a stage is not requested via cmdline, its activation in the profile has no effect. When creating a profile, it's currently necessary to start from the everything-profile and set unwanted stages to `false`. If the provided profile file is not found at the given path, the tool will lookup a file with that name at the location of the other predefined profiles (`<install_or_src_path>/src/aiu_trace_analyzer/profiles`).
 
 

--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -627,7 +627,7 @@ class Acelyzer:
                 csv_fname=args.output,
                 soc_freq=self.freq_soc,
                 core_freq=self.freq_core,
-                compiler_info=args.compiler_info)
+                compiler_infos=args.compiler_info)
             process.register_stage(callback=event_pipe.compute_utilization_fingerprints, context=rcu_util_ctx)
 
         ##############################################################

--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -258,7 +258,7 @@ class Acelyzer:
                             " compile-time data references. Required e.g. for rcu_util counters."
                             " Multi-AIU rank outputs need to be sorted by rank.")
 
-        parser.add_argument("-d", "--inductor_spyre_dir", type=str, default="/tmp/torchinductor_ac",
+        parser.add_argument("-d", "--inductor_spyre_dir", type=str, default=None,
                             help="Path to the inductor_spyre directory containing "
                             "inductor_spyre/<kernel_name>/perf/ideal_cycles.json files.")
 

--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -257,9 +257,9 @@ class Acelyzer:
                             help="(Comma-separated list of per-rank) Path/Filename of compiler log to ingest"
                             " compile-time data references. Required e.g. for rcu_util counters."
                             " Multi-AIU rank outputs need to be sorted by rank.")
-        
-        parser.add_argument("-d", "--inductor_spyre_dir", type=str, default="/tmp/torchinductor_ac",                                                                                
-                            help="Path to the inductor_spyre directory containing " \
+
+        parser.add_argument("-d", "--inductor_spyre_dir", type=str, default="/tmp/torchinductor_ac",
+                            help="Path to the inductor_spyre directory containing "
                             "inductor_spyre/<kernel_name>/perf/ideal_cycles.json files.")
 
         parser.add_argument("-D", "--loglevel", type=int, default=self.defaults["loglevel"],
@@ -450,9 +450,9 @@ class Acelyzer:
             aiulog.log(aiulog.ERROR, "power_ts3 and power_ts4 are mutually exclusive")
             return False
 
-        if "rcu_util" in args.counter and args.compiler_log is None and args.inductor_spyre_dir is None :
-            aiulog.log(aiulog.WARN, "rcu_util counter requested but no compiler log/inductor spyre directory path provided."
-                       " No utilization will be plotted.")
+        if "rcu_util" in args.counter and args.compiler_log is None and args.inductor_spyre_dir is None:
+            aiulog.log(aiulog.WARN, "rcu_util counter requested but no compiler log/inductor spyre"
+                       " directory path provided. No utilization will be plotted.")
 
         return True
 

--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -257,6 +257,10 @@ class Acelyzer:
                             help="(Comma-separated list of per-rank) Path/Filename of compiler log to ingest"
                             " compile-time data references. Required e.g. for rcu_util counters."
                             " Multi-AIU rank outputs need to be sorted by rank.")
+        
+        parser.add_argument("-d", "--inductor_spyre_dir", type=str, default="/tmp/torchinductor_ac",                                                                                
+                            help="Path to the inductor_spyre directory containing " \
+                            "inductor_spyre/<kernel_name>/perf/ideal_cycles.json files.")
 
         parser.add_argument("-D", "--loglevel", type=int, default=self.defaults["loglevel"],
                             choices=range(0, 5), help="Logging level 0(ERROR)..4(TRACE)")
@@ -446,8 +450,8 @@ class Acelyzer:
             aiulog.log(aiulog.ERROR, "power_ts3 and power_ts4 are mutually exclusive")
             return False
 
-        if "rcu_util" in args.counter and args.compiler_log is None:
-            aiulog.log(aiulog.WARN, "rcu_util counter requested but no compiler log provided."
+        if "rcu_util" in args.counter and args.compiler_log is None and args.inductor_spyre_dir is None :
+            aiulog.log(aiulog.WARN, "rcu_util counter requested but no compiler log/inductor spyre directory path provided."
                        " No utilization will be plotted.")
 
         return True
@@ -614,12 +618,25 @@ class Acelyzer:
             data_transfer_compute_ctx = event_pipe.DataTransferExtractionContext()
             process.register_stage(callback=event_pipe.compute_bandwidth, context=data_transfer_compute_ctx)
 
+        ##############################################################
+        # RCU Util calculation
+        if args.compiler_log and args.inductor_spyre_dir:
+            aiulog.log(aiulog.ERROR, "Both -c and -d cannot be specified.")
+
         if any(args.counter) and "rcu_util" in args.counter and args.compiler_log:
             rcu_util_ctx = event_pipe.MultiRCUUtilizationContext(
-                compiler_log=args.compiler_log,
                 csv_fname=args.output,
                 soc_freq=self.freq_soc,
-                core_freq=self.freq_core)
+                core_freq=self.freq_core,
+                compiler_log=args.compiler_log)
+            process.register_stage(callback=event_pipe.compute_utilization_fingerprints, context=rcu_util_ctx)
+
+        if any(args.counter) and "rcu_util" in args.counter and args.inductor_spyre_dir:
+            rcu_util_ctx = event_pipe.MultiRCUUtilizationContext(
+                csv_fname=args.output,
+                soc_freq=self.freq_soc,
+                core_freq=self.freq_core,
+                inductor_spyre_dir=args.inductor_spyre_dir)
             process.register_stage(callback=event_pipe.compute_utilization_fingerprints, context=rcu_util_ctx)
 
         ##############################################################
@@ -635,7 +652,7 @@ class Acelyzer:
         if args.comm_summarize_seq:
             process.register_stage(callback=event_pipe.communication_event_apply, context=communication_event_ctx)
 
-        if any(args.counter) and "rcu_util" in args.counter and args.compiler_log:
+        if any(args.counter) and "rcu_util" in args.counter and (args.compiler_log or args.inductor_spyre_dir):
             process.register_stage(callback=event_pipe.compute_utilization, context=rcu_util_ctx)
 
         # register callback to to the power counter sorting

--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -627,7 +627,7 @@ class Acelyzer:
                 csv_fname=args.output,
                 soc_freq=self.freq_soc,
                 core_freq=self.freq_core,
-                compiler_infos=args.compiler_info)
+                compiler_info=args.compiler_info)
             process.register_stage(callback=event_pipe.compute_utilization_fingerprints, context=rcu_util_ctx)
 
         ##############################################################

--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -253,14 +253,13 @@ class Acelyzer:
                             help="Space-separated list of counters to extract/display."
                             " Note: power_ts4 and power_ts3 are mutually exclusive.")
 
-        parser.add_argument("-c", "--compiler_log", type=str, default=None,
-                            help="(Comma-separated list of per-rank) Path/Filename of compiler log to ingest"
-                            " compile-time data references. Required e.g. for rcu_util counters."
-                            " Multi-AIU rank outputs need to be sorted by rank.")
-
-        parser.add_argument("-d", "--inductor_spyre_dir", type=str, default=None,
-                            help="Path to the inductor_spyre directory containing "
-                            "inductor_spyre/<kernel_name>/perf/ideal_cycles.json files.")
+        parser.add_argument("-c", "--compiler_info", type=str, default=None,
+                            help="For existing AIU stack: (Comma-separated list of per-rank)"
+                            " Path/Filename of compiler log to ingest compile-time data references."
+                            " Required e.g. for rcu_util counters."
+                            " Multi-AIU rank outputs need to be sorted by rank."
+                            " For torch-spyre stack: Path to the inductor_spyre directory containing "
+                            " inductor_spyre/<kernel_name>/perf/ideal_cycles.json files.")
 
         parser.add_argument("-D", "--loglevel", type=int, default=self.defaults["loglevel"],
                             choices=range(0, 5), help="Logging level 0(ERROR)..4(TRACE)")
@@ -450,9 +449,12 @@ class Acelyzer:
             aiulog.log(aiulog.ERROR, "power_ts3 and power_ts4 are mutually exclusive")
             return False
 
-        if "rcu_util" in args.counter and args.compiler_log is None and args.inductor_spyre_dir is None:
-            aiulog.log(aiulog.WARN, "rcu_util counter requested but no compiler log/inductor spyre"
-                       " directory path provided. No utilization will be plotted.")
+        if "rcu_util" in args.counter:
+            if args.compiler_info is None:
+                aiulog.log(aiulog.WARN, "rcu_util counter requested but no compiler log/inductor spyre"
+                                        " directory path provided. No utilization will be plotted.")
+            elif not os.path.exists(args.compiler_info):
+                aiulog.log(aiulog.WARN, "Invalid directory path provided. No utilization will be plotted.")
 
         return True
 
@@ -620,23 +622,12 @@ class Acelyzer:
 
         ##############################################################
         # RCU Util calculation
-        if args.compiler_log and args.inductor_spyre_dir:
-            aiulog.log(aiulog.ERROR, "Both -c and -d cannot be specified.")
-
-        if any(args.counter) and "rcu_util" in args.counter and args.compiler_log:
+        if any(args.counter) and "rcu_util" in args.counter and args.compiler_info:
             rcu_util_ctx = event_pipe.MultiRCUUtilizationContext(
                 csv_fname=args.output,
                 soc_freq=self.freq_soc,
                 core_freq=self.freq_core,
-                compiler_log=args.compiler_log)
-            process.register_stage(callback=event_pipe.compute_utilization_fingerprints, context=rcu_util_ctx)
-
-        if any(args.counter) and "rcu_util" in args.counter and args.inductor_spyre_dir:
-            rcu_util_ctx = event_pipe.MultiRCUUtilizationContext(
-                csv_fname=args.output,
-                soc_freq=self.freq_soc,
-                core_freq=self.freq_core,
-                inductor_spyre_dir=args.inductor_spyre_dir)
+                compiler_info=args.compiler_info)
             process.register_stage(callback=event_pipe.compute_utilization_fingerprints, context=rcu_util_ctx)
 
         ##############################################################
@@ -652,7 +643,7 @@ class Acelyzer:
         if args.comm_summarize_seq:
             process.register_stage(callback=event_pipe.communication_event_apply, context=communication_event_ctx)
 
-        if any(args.counter) and "rcu_util" in args.counter and (args.compiler_log or args.inductor_spyre_dir):
+        if any(args.counter) and "rcu_util" in args.counter and args.compiler_info:
             process.register_stage(callback=event_pipe.compute_utilization, context=rcu_util_ctx)
 
         # register callback to to the power counter sorting

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -570,7 +570,7 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
             csv_fname: str,
             soc_freq: float,
             core_freq: float,
-            compiler_infos: str = None) -> None:
+            compiler_info: str = None) -> None:
 
         super().__init__(warnings=[
             # count the number of events with >100% utilization (indication of table mismatch)
@@ -596,7 +596,7 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
             )
         ])
 
-        log_list = compiler_infos.split(",")
+        log_list = compiler_info.split(",")
         self.multi_log = (len(log_list) > 1)
         self.fingerprints: dict[int, RCUTableFingerprint] = {}   # fingerprints per job/file
         if self.multi_log:

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -233,18 +233,23 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
 
         self.initialize_tables()
 
-        try:
-            if os.path.isfile(compiler_info):
-                # Workload is running on current stack
+        if os.path.isfile(compiler_info):                                                                                     
+            # Workload is running on current stack                                                                              
+            try:        
                 subdir, fpat = '/'.join(compiler_info.split('/')[:-1]), compiler_info.split('/')[-1]
                 compiler_log_name = list(pathlib.Path(subdir).rglob(fpat))[0]
                 self.extract_tables(compiler_log=compiler_log_name)
-            elif os.path.isdir(compiler_info):
-                # Workload is running on the Torch Spyre stack
+            except Exception as e:
+                aiulog.log(aiulog.ERROR, "UTL: Unable to read open/parse compiler info file.", compiler_info, e)
+        elif os.path.isdir(compiler_info):
+            # Workload is running on the Torch Spyre stack
+            try:
                 self.extract_tables_from_inductor_dir(compiler_info)
-        except Exception as e:
-            aiulog.log(aiulog.ERROR, "UTL: Unable to read open/parse compiler info file.", compiler_info, e)
-
+            except Exception as e:
+                aiulog.log(aiulog.ERROR, "UTL: Unable to read open/parse compiler info file.", compiler_info, e)
+        else:
+            raise ValueError(f"{compiler_info} Unrecognized compiler info file type. Expecting file or directory.")
+        
         for _, t in self.kernel_cycles.items():
             self.autopilot_detail = AutopilotDetail(t)
             self.table_hash = self.autopilot_detail.table_hash()

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -202,8 +202,7 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
             csv_fname: str,
             soc_freq: float,
             core_freq: float,
-            compiler_log: str = None,
-            inductor_spyre_dir: str = None,
+            compiler_info: str = None,
             kernel_db_url: str = "ai_kernel.db") -> None:
 
         super().__init__(warnings=[
@@ -233,18 +232,22 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
         aiulog.log(aiulog.DEBUG, "UTL: Input Ideal Cycle To Clock factor", self.cycle_to_clock_factor)
 
         self.initialize_tables()
-        if compiler_log is not None and inductor_spyre_dir is None:
+
+        if os.path.isfile(compiler_info):
+            # Workload is running on current stack
             try:
-                subdir, fpat = '/'.join(compiler_log.split('/')[:-1]), compiler_log.split('/')[-1]
+                subdir, fpat = '/'.join(compiler_info.split('/')[:-1]), compiler_info.split('/')[-1]
                 compiler_log_name = list(pathlib.Path(subdir).rglob(fpat))[0]
                 self.extract_tables(compiler_log=compiler_log_name)
             except Exception as e:
-                aiulog.log(aiulog.ERROR, "UTL: Unable to open/parse log file.", compiler_log, e)
-        elif compiler_log is None and inductor_spyre_dir is not None:
+                aiulog.log(aiulog.ERROR, "UTL: Unable to open/parse log file.", compiler_info, e)
+
+        elif os.path.isdir(compiler_info):
+            # Workload is running on the Torch Spyre stack
             try:
-                self.extract_tables_from_inductor_dir(inductor_spyre_dir)
+                self.extract_tables_from_inductor_dir(compiler_info)
             except Exception as e:
-                aiulog.log(aiulog.ERROR, "UTL: Unable to read inductor perf JSON files.", inductor_spyre_dir, e)
+                aiulog.log(aiulog.ERROR, "UTL: Unable to read inductor perf JSON files.", compiler_info, e)
 
         for _, t in self.kernel_cycles.items():
             self.autopilot_detail = AutopilotDetail(t)
@@ -571,7 +574,7 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
             csv_fname: str,
             soc_freq: float,
             core_freq: float,
-            compiler_info: str = None) -> None:
+            compiler_infos: str = None) -> None:
 
         super().__init__(warnings=[
             # count the number of events with >100% utilization (indication of table mismatch)
@@ -596,56 +599,29 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
                 update_fn={"count": int.__add__, "joblist": set.union}
             )
         ])
+        
+        log_list = compiler_infos.split(",")
+        self.multi_log = (len(log_list) > 1)
+        self.fingerprints: dict[int, RCUTableFingerprint] = {}   # fingerprints per job/file
+        if self.multi_log:
+            aiulog.log(aiulog.INFO, "UTL: Multi-AIU logs provided. Entries:", len(log_list))
 
-        if os.path.isfile(compiler_info):
-            # Workload is running on current stack
-            log_list = compiler_info.split(",")
-            self.multi_log = (len(log_list) > 1)
-            self.fingerprints: dict[int, RCUTableFingerprint] = {}   # fingerprints per job/file
+        # event rank will be multiplied by this factor to make the key for the correct rcuctx
+        # in single-log case: will turn everything into zero, otherwise use event rank
+        self.rank_factor = 1 if self.multi_log else 0
+
+        self.rcuctx: dict[int, RCUUtilizationContext] = {}
+        for rank, log in enumerate(log_list):
+            aiulog.log(aiulog.DEBUG, "UTL: Building kernel table for", rank)
             if self.multi_log:
-                aiulog.log(aiulog.INFO, "UTL: Multi-AIU logs provided. Entries:", len(log_list))
-
-            # event rank will be multiplied by this factor to make the key for the correct rcuctx
-            # in single-log case: will turn everything into zero, otherwise use event rank
-            self.rank_factor = 1 if self.multi_log else 0
-
-            self.rcuctx: dict[int, RCUUtilizationContext] = {}
-            for rank, log in enumerate(log_list):
-                aiulog.log(aiulog.DEBUG, "UTL: Building kernel table for", rank)
-                if self.multi_log:
-                    csv_basename = csv_fname + str(rank)
-                else:
-                    csv_basename = csv_fname
-                self.rcuctx[rank] = RCUUtilizationContext(
-                    csv_fname=csv_basename,
-                    soc_freq=soc_freq,
-                    core_freq=core_freq,
-                    compiler_log=log)
-
-        elif os.path.isdir(compiler_info):
-            # Workload is running on the Torch Spyre stack
-            log_list = compiler_info.split(",")
-            self.multi_log = (len(log_list) > 1)
-            self.fingerprints: dict[int, RCUTableFingerprint] = {}   # fingerprints per job/file
-            if self.multi_log:
-                aiulog.log(aiulog.INFO, "UTL: Multi-AIU logs provided. Entries:", len(log_list))
-
-            # event rank will be multiplied by this factor to make the key for the correct rcuctx
-            # in single-log case: will turn everything into zero, otherwise use event rank
-            self.rank_factor = 1 if self.multi_log else 0
-
-            self.rcuctx: dict[int, RCUUtilizationContext] = {}
-            for rank, log in enumerate(log_list):
-                aiulog.log(aiulog.DEBUG, "UTL: Building kernel table for", rank)
-                if self.multi_log:
-                    csv_basename = csv_fname + str(rank)
-                else:
-                    csv_basename = csv_fname
-                self.rcuctx[rank] = RCUUtilizationContext(
-                    csv_fname=csv_basename,
-                    soc_freq=soc_freq,
-                    core_freq=core_freq,
-                    inductor_spyre_dir=log)
+                csv_basename = csv_fname + str(rank)
+            else:
+                csv_basename = csv_fname
+            self.rcuctx[rank] = RCUUtilizationContext(
+                csv_fname=csv_basename,
+                soc_freq=soc_freq,
+                core_freq=core_freq,
+                compiler_info=log)
 
     def enable(self) -> bool:
         for _, ctx in self.rcuctx.items():

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -230,8 +230,10 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
         aiulog.log(aiulog.DEBUG, "UTL: Input Ideal Cycle To Clock factor", self.cycle_to_clock_factor)
 
         self.initialize_tables()
-
-        if os.path.isfile(compiler_info):
+        
+        if compiler_info is None:                                                                                               
+            pass                                                                                                                
+        elif os.path.isfile(compiler_info):
             # Workload is running on current stack
             try:
                 subdir, fpat = '/'.join(compiler_info.split('/')[:-1]), compiler_info.split('/')[-1]

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -230,7 +230,7 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
         aiulog.log(aiulog.DEBUG, "UTL: Input Ideal Cycle To Clock factor", self.cycle_to_clock_factor)
 
         self.initialize_tables()
-        
+
         try:
             if os.path.isfile(compiler_info):
                 # Workload is running on current stack

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -1,5 +1,6 @@
 # Copyright 2024-2025 IBM Corporation
 
+import os
 import re
 import copy
 import json
@@ -570,8 +571,7 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
             csv_fname: str,
             soc_freq: float,
             core_freq: float,
-            compiler_log: str = None,
-            inductor_spyre_dir: str = None) -> None:
+            compiler_info: str = None) -> None:
 
         super().__init__(warnings=[
             # count the number of events with >100% utilization (indication of table mismatch)
@@ -597,8 +597,9 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
             )
         ])
 
-        if compiler_log is not None and inductor_spyre_dir is None:
-            log_list = compiler_log.split(",")
+        if os.path.isfile(compiler_info):
+            # Workload is running on current stack
+            log_list = compiler_info.split(",")
             self.multi_log = (len(log_list) > 1)
             self.fingerprints: dict[int, RCUTableFingerprint] = {}   # fingerprints per job/file
             if self.multi_log:
@@ -621,8 +622,9 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
                     core_freq=core_freq,
                     compiler_log=log)
 
-        elif compiler_log is None and inductor_spyre_dir is not None:
-            log_list = inductor_spyre_dir.split(",")
+        elif os.path.isdir(compiler_info):
+            # Workload is running on the Torch Spyre stack
+            log_list = compiler_info.split(",")
             self.multi_log = (len(log_list) > 1)
             self.fingerprints: dict[int, RCUTableFingerprint] = {}   # fingerprints per job/file
             if self.multi_log:

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -599,7 +599,7 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
                 update_fn={"count": int.__add__, "joblist": set.union}
             )
         ])
-        
+
         log_list = compiler_infos.split(",")
         self.multi_log = (len(log_list) > 1)
         self.fingerprints: dict[int, RCUTableFingerprint] = {}   # fingerprints per job/file

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -233,21 +233,17 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
 
         self.initialize_tables()
 
-        if os.path.isfile(compiler_info):
-            # Workload is running on current stack
-            try:
+        try:
+            if os.path.isfile(compiler_info):
+                # Workload is running on current stack
                 subdir, fpat = '/'.join(compiler_info.split('/')[:-1]), compiler_info.split('/')[-1]
                 compiler_log_name = list(pathlib.Path(subdir).rglob(fpat))[0]
                 self.extract_tables(compiler_log=compiler_log_name)
-            except Exception as e:
-                aiulog.log(aiulog.ERROR, "UTL: Unable to open/parse log file.", compiler_info, e)
-
-        elif os.path.isdir(compiler_info):
-            # Workload is running on the Torch Spyre stack
-            try:
+            elif os.path.isdir(compiler_info):
+                # Workload is running on the Torch Spyre stack
                 self.extract_tables_from_inductor_dir(compiler_info)
-            except Exception as e:
-                aiulog.log(aiulog.ERROR, "UTL: Unable to read inductor perf JSON files.", compiler_info, e)
+        except Exception as e:
+                aiulog.log(aiulog.ERROR, "UTL: Unable to read open/parse compiler info file.", compiler_info, e)
 
         for _, t in self.kernel_cycles.items():
             self.autopilot_detail = AutopilotDetail(t)

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -243,7 +243,7 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
                 # Workload is running on the Torch Spyre stack
                 self.extract_tables_from_inductor_dir(compiler_info)
         except Exception as e:
-                aiulog.log(aiulog.ERROR, "UTL: Unable to read open/parse compiler info file.", compiler_info, e)
+            aiulog.log(aiulog.ERROR, "UTL: Unable to read open/parse compiler info file.", compiler_info, e)
 
         for _, t in self.kernel_cycles.items():
             self.autopilot_detail = AutopilotDetail(t)

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -233,9 +233,9 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
 
         self.initialize_tables()
 
-        if os.path.isfile(compiler_info):                                                                                     
-            # Workload is running on current stack                                                                              
-            try:        
+        if os.path.isfile(compiler_info):
+            # Workload is running on current stack
+            try:
                 subdir, fpat = '/'.join(compiler_info.split('/')[:-1]), compiler_info.split('/')[-1]
                 compiler_log_name = list(pathlib.Path(subdir).rglob(fpat))[0]
                 self.extract_tables(compiler_log=compiler_log_name)
@@ -249,7 +249,7 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
                 aiulog.log(aiulog.ERROR, "UTL: Unable to read open/parse compiler info file.", compiler_info, e)
         else:
             raise ValueError(f"{compiler_info} Unrecognized compiler info file type. Expecting file or directory.")
-        
+
         for _, t in self.kernel_cycles.items():
             self.autopilot_detail = AutopilotDetail(t)
             self.table_hash = self.autopilot_detail.table_hash()

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -620,7 +620,7 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
                     soc_freq=soc_freq,
                     core_freq=core_freq,
                     compiler_log=log)
-                
+
         elif compiler_log is None and inductor_spyre_dir is not None:
             log_list = inductor_spyre_dir.split(",")
             self.multi_log = (len(log_list) > 1)
@@ -644,7 +644,6 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
                     soc_freq=soc_freq,
                     core_freq=core_freq,
                     inductor_spyre_dir=log)
-        
 
     def enable(self) -> bool:
         for _, ctx in self.rcuctx.items():

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -2,6 +2,7 @@
 
 import re
 import copy
+import json
 from math import isclose
 import pathlib
 from enum import Flag, auto
@@ -122,6 +123,7 @@ class RCUTableFingerprint():
                 f"0.0  <- ({other.totaltime} / {self.totaltime} = {other.totaltime / self.totaltime})")
             return 0.0
 
+        # TODO: Add check for self.totaltime != 0
         sim_val += self.sim_weights["total_time"] * (other.totaltime / self.totaltime)
         aiulog.log(
             aiulog.DEBUG, "   SIMVAL(totaltim):",
@@ -196,10 +198,11 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
 
     def __init__(
             self,
-            compiler_log: str,
             csv_fname: str,
             soc_freq: float,
             core_freq: float,
+            compiler_log: str = None,
+            inductor_spyre_dir: str = None,
             kernel_db_url: str = "ai_kernel.db") -> None:
 
         super().__init__(warnings=[
@@ -229,12 +232,18 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
         aiulog.log(aiulog.DEBUG, "UTL: Input Ideal Cycle To Clock factor", self.cycle_to_clock_factor)
 
         self.initialize_tables()
-        try:
-            subdir, fpat = '/'.join(compiler_log.split('/')[:-1]), compiler_log.split('/')[-1]
-            compiler_log_name = list(pathlib.Path(subdir).rglob(fpat))[0]
-            self.extract_tables(compiler_log=compiler_log_name)
-        except Exception as e:
-            aiulog.log(aiulog.ERROR, "UTL: Unable to open/parse log file.", compiler_log, e)
+        if compiler_log is not None and inductor_spyre_dir is None:
+            try:
+                subdir, fpat = '/'.join(compiler_log.split('/')[:-1]), compiler_log.split('/')[-1]
+                compiler_log_name = list(pathlib.Path(subdir).rglob(fpat))[0]
+                self.extract_tables(compiler_log=compiler_log_name)
+            except Exception as e:
+                aiulog.log(aiulog.ERROR, "UTL: Unable to open/parse log file.", compiler_log, e)
+        elif compiler_log is None and inductor_spyre_dir is not None:
+            try:
+                self.extract_tables_from_inductor_dir(inductor_spyre_dir)
+            except Exception as e:
+                aiulog.log(aiulog.ERROR, "UTL: Unable to read inductor perf JSON files.", inductor_spyre_dir, e)
 
         for _, t in self.kernel_cycles.items():
             self.autopilot_detail = AutopilotDetail(t)
@@ -419,6 +428,29 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
                 if not keep_parsing:
                     break
 
+    def extract_tables_from_inductor_dir(self, inductor_spyre_dir: str):
+        base = pathlib.Path(inductor_spyre_dir) / "inductor-spyre"
+        current_table, fprint = self._start_init_table("UNKN")
+        for kernel_dir in sorted(base.iterdir()):
+            if not kernel_dir.is_dir():
+                continue
+            json_path = kernel_dir / "perf" / "ideal_cycles.json"
+            if not json_path.exists():
+                continue
+            kernel_name = kernel_dir.name + " Cmpt Exec"
+            with open(json_path) as f:
+                entries = json.load(f)
+            for entry in entries:
+                cycles = entry["ideal_cycles"]
+                category = entry["op_category"]
+                fprint.add(kernel_name, cycles * self.cycle_to_clock_factor)
+                if kernel_name not in current_table:
+                    if cycles != 0:
+                        current_table[kernel_name] = cycles
+                if kernel_name not in self.kernel_cat_map[0]:
+                    self.kernel_cat_map[0].add(kernel_name, category)
+        self._finish_add_table(fprint, current_table)
+
     @staticmethod
     def _compute_row_stats(dur, total, ideal, ideal_total):
         dur_frac = 0 if isclose(total, 0.0, abs_tol=1e-9) else round(dur / total, 4)
@@ -535,10 +567,11 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
 
     def __init__(
             self,
-            compiler_log: str,
             csv_fname: str,
             soc_freq: float,
-            core_freq: float) -> None:
+            core_freq: float,
+            compiler_log: str = None,
+            inductor_spyre_dir: str = None) -> None:
 
         super().__init__(warnings=[
             # count the number of events with >100% utilization (indication of table mismatch)
@@ -564,28 +597,54 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
             )
         ])
 
-        log_list = compiler_log.split(",")
-        self.multi_log = (len(log_list) > 1)
-        self.fingerprints: dict[int, RCUTableFingerprint] = {}   # fingerprints per job/file
-        if self.multi_log:
-            aiulog.log(aiulog.INFO, "UTL: Multi-AIU logs provided. Entries:", len(log_list))
-
-        # event rank will be multiplied by this factor to make the key for the correct rcuctx
-        # in single-log case: will turn everything into zero, otherwise use event rank
-        self.rank_factor = 1 if self.multi_log else 0
-
-        self.rcuctx: dict[int, RCUUtilizationContext] = {}
-        for rank, log in enumerate(log_list):
-            aiulog.log(aiulog.DEBUG, "UTL: Building kernel table for", rank)
+        if compiler_log is not None and inductor_spyre_dir is None:
+            log_list = compiler_log.split(",")
+            self.multi_log = (len(log_list) > 1)
+            self.fingerprints: dict[int, RCUTableFingerprint] = {}   # fingerprints per job/file
             if self.multi_log:
-                csv_basename = csv_fname + str(rank)
-            else:
-                csv_basename = csv_fname
-            self.rcuctx[rank] = RCUUtilizationContext(
-                log,
-                csv_fname=csv_basename,
-                soc_freq=soc_freq,
-                core_freq=core_freq)
+                aiulog.log(aiulog.INFO, "UTL: Multi-AIU logs provided. Entries:", len(log_list))
+
+            # event rank will be multiplied by this factor to make the key for the correct rcuctx
+            # in single-log case: will turn everything into zero, otherwise use event rank
+            self.rank_factor = 1 if self.multi_log else 0
+
+            self.rcuctx: dict[int, RCUUtilizationContext] = {}
+            for rank, log in enumerate(log_list):
+                aiulog.log(aiulog.DEBUG, "UTL: Building kernel table for", rank)
+                if self.multi_log:
+                    csv_basename = csv_fname + str(rank)
+                else:
+                    csv_basename = csv_fname
+                self.rcuctx[rank] = RCUUtilizationContext(
+                    csv_fname=csv_basename,
+                    soc_freq=soc_freq,
+                    core_freq=core_freq,
+                    compiler_log=log)
+                
+        elif compiler_log is None and inductor_spyre_dir is not None:
+            log_list = inductor_spyre_dir.split(",")
+            self.multi_log = (len(log_list) > 1)
+            self.fingerprints: dict[int, RCUTableFingerprint] = {}   # fingerprints per job/file
+            if self.multi_log:
+                aiulog.log(aiulog.INFO, "UTL: Multi-AIU logs provided. Entries:", len(log_list))
+
+            # event rank will be multiplied by this factor to make the key for the correct rcuctx
+            # in single-log case: will turn everything into zero, otherwise use event rank
+            self.rank_factor = 1 if self.multi_log else 0
+
+            self.rcuctx: dict[int, RCUUtilizationContext] = {}
+            for rank, log in enumerate(log_list):
+                aiulog.log(aiulog.DEBUG, "UTL: Building kernel table for", rank)
+                if self.multi_log:
+                    csv_basename = csv_fname + str(rank)
+                else:
+                    csv_basename = csv_fname
+                self.rcuctx[rank] = RCUUtilizationContext(
+                    csv_fname=csv_basename,
+                    soc_freq=soc_freq,
+                    core_freq=core_freq,
+                    inductor_spyre_dir=log)
+        
 
     def enable(self) -> bool:
         for _, ctx in self.rcuctx.items():

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -231,24 +231,19 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
 
         self.initialize_tables()
         
-        if compiler_info is None:                                                                                               
-            pass                                                                                                                
-        elif os.path.isfile(compiler_info):
-            # Workload is running on current stack
-            try:
+        try:
+            if os.path.isfile(compiler_info):
+                # Workload is running on current stack
                 subdir, fpat = '/'.join(compiler_info.split('/')[:-1]), compiler_info.split('/')[-1]
                 compiler_log_name = list(pathlib.Path(subdir).rglob(fpat))[0]
                 self.extract_tables(compiler_log=compiler_log_name)
-            except Exception as e:
-                aiulog.log(aiulog.ERROR, "UTL: Unable to read open/parse compiler info file.", compiler_info, e)
-        elif os.path.isdir(compiler_info):
-            # Workload is running on the Torch Spyre stack
-            try:
+            elif os.path.isdir(compiler_info):
+                # Workload is running on the Torch Spyre stack
                 self.extract_tables_from_inductor_dir(compiler_info)
-            except Exception as e:
-                aiulog.log(aiulog.ERROR, "UTL: Unable to read open/parse compiler info file.", compiler_info, e)
-        else:
-            raise ValueError(f"{compiler_info} Unrecognized compiler info file type. Expecting file or directory.")
+            else:
+                raise ValueError(f"{compiler_info} Unrecognized compiler info file type. Expecting file or directory.")
+        except Exception as e:
+            aiulog.log(aiulog.ERROR, "UTL: Unable to read open/parse compiler info file.", compiler_info, e)
 
         for _, t in self.kernel_cycles.items():
             self.autopilot_detail = AutopilotDetail(t)

--- a/tests/aiu_trace_analyzer/pipeline/test_rcu_utilization.py
+++ b/tests/aiu_trace_analyzer/pipeline/test_rcu_utilization.py
@@ -22,7 +22,7 @@ def logfile():
 # setup the context class instance with a table as a fixture
 @pytest.fixture
 def rcu(logfile: str, tmp_path):
-    return RCUUtilizationContext(compiler_log=logfile,
+    return RCUUtilizationContext(compiler_info=logfile,
                                  csv_fname=f'{tmp_path}/test_output.json',
                                  soc_freq=1000,
                                  core_freq=800)
@@ -31,7 +31,7 @@ def rcu(logfile: str, tmp_path):
 # setup a context class instance without table as a fixture
 @pytest.fixture
 def rcu_without_table(tmp_path):
-    return RCUUtilizationContext(compiler_log=None,
+    return RCUUtilizationContext(compiler_info=None,
                                  soc_freq=1000,
                                  core_freq=800,
                                  csv_fname=f'{tmp_path}/test_output.json')
@@ -39,7 +39,7 @@ def rcu_without_table(tmp_path):
 
 @pytest.fixture
 def multircu_single(logfile: str, tmp_path):
-    return MultiRCUUtilizationContext(compiler_info=logfile,
+    return MultiRCUUtilizationContext(compiler_infos=logfile,
                                       csv_fname=f'{tmp_path}/test_output.json',
                                       soc_freq=1000,
                                       core_freq=800)

--- a/tests/aiu_trace_analyzer/pipeline/test_rcu_utilization.py
+++ b/tests/aiu_trace_analyzer/pipeline/test_rcu_utilization.py
@@ -22,7 +22,7 @@ def logfile():
 # setup the context class instance with a table as a fixture
 @pytest.fixture
 def rcu(logfile: str, tmp_path):
-    return RCUUtilizationContext(compiler_log=logfile,
+    return RCUUtilizationContext(compiler_info=logfile,
                                  csv_fname=f'{tmp_path}/test_output.json',
                                  soc_freq=1000,
                                  core_freq=800)
@@ -31,7 +31,7 @@ def rcu(logfile: str, tmp_path):
 # setup a context class instance without table as a fixture
 @pytest.fixture
 def rcu_without_table(tmp_path):
-    return RCUUtilizationContext(compiler_log=None,
+    return RCUUtilizationContext(compiler_info=None,
                                  soc_freq=1000,
                                  core_freq=800,
                                  csv_fname=f'{tmp_path}/test_output.json')
@@ -39,7 +39,7 @@ def rcu_without_table(tmp_path):
 
 @pytest.fixture
 def multircu_single(logfile: str, tmp_path):
-    return MultiRCUUtilizationContext(compiler_log=logfile,
+    return MultiRCUUtilizationContext(compiler_info=logfile,
                                       csv_fname=f'{tmp_path}/test_output.json',
                                       soc_freq=1000,
                                       core_freq=800)

--- a/tests/aiu_trace_analyzer/pipeline/test_rcu_utilization.py
+++ b/tests/aiu_trace_analyzer/pipeline/test_rcu_utilization.py
@@ -22,7 +22,7 @@ def logfile():
 # setup the context class instance with a table as a fixture
 @pytest.fixture
 def rcu(logfile: str, tmp_path):
-    return RCUUtilizationContext(compiler_info=logfile,
+    return RCUUtilizationContext(compiler_log=logfile,
                                  csv_fname=f'{tmp_path}/test_output.json',
                                  soc_freq=1000,
                                  core_freq=800)
@@ -31,7 +31,7 @@ def rcu(logfile: str, tmp_path):
 # setup a context class instance without table as a fixture
 @pytest.fixture
 def rcu_without_table(tmp_path):
-    return RCUUtilizationContext(compiler_info=None,
+    return RCUUtilizationContext(compiler_log=None,
                                  soc_freq=1000,
                                  core_freq=800,
                                  csv_fname=f'{tmp_path}/test_output.json')

--- a/tests/aiu_trace_analyzer/pipeline/test_rcu_utilization.py
+++ b/tests/aiu_trace_analyzer/pipeline/test_rcu_utilization.py
@@ -39,7 +39,7 @@ def rcu_without_table(tmp_path):
 
 @pytest.fixture
 def multircu_single(logfile: str, tmp_path):
-    return MultiRCUUtilizationContext(compiler_infos=logfile,
+    return MultiRCUUtilizationContext(compiler_info=logfile,
                                       csv_fname=f'{tmp_path}/test_output.json',
                                       soc_freq=1000,
                                       core_freq=800)


### PR DESCRIPTION
This PR fixes the rcu_utilization calculation for the torch spyre stack by using the ideal_cycles.json to obtain the ideal cycles per op.