### PR TITLE
fix prep-event parsing for queuing counter creation

### DIFF
--- a/src/aiu_trace_analyzer/pipeline/cmpt_collection.py
+++ b/src/aiu_trace_analyzer/pipeline/cmpt_collection.py
@@ -1,10 +1,10 @@
 # Copyright 2024-2025 IBM Corporation
 
 import copy
-import re
 
 import aiu_trace_analyzer.logger as aiulog
-from aiu_trace_analyzer.types import TraceEvent, GlobalIngestData
+from aiu_trace_analyzer.pipeline.tools import PipelineContextTool
+from aiu_trace_analyzer.types import TraceEvent
 from aiu_trace_analyzer.pipeline import AbstractContext, AbstractHashQueueContext
 
 
@@ -94,12 +94,13 @@ class QueueingCounterContext(AbstractHashQueueContext):
 
 
 def queueing_counter(event: TraceEvent, queue_coll: AbstractContext, keyval: dict) -> list[TraceEvent]:
+    assert isinstance(queue_coll, QueueingCounterContext), "queue_coll must be a QueueingCounterContext"
+
     revents = [event]
     keep_prep = keyval.get("keep_prep", False)
 
     if event["ph"] in "X":
-        dialect = GlobalIngestData.get_dialect(event["args"]["jobhash"])
-        if re.search(dialect.get("acc_compute_prep"), event["name"]) is None:
+        if not PipelineContextTool.is_category(event, "acc_compute_prep"):
             return revents
 
         if keep_prep:


### PR DESCRIPTION
Parsing flex traces had a regression caused by introduction of event classification. At that time, the way to handle dialect-specific names was changed to use `PipelineContextTool.is_category` instead of regex search of the string provided in the dialect map. The code in `cmpt_collection.py` was not updated accordingly.

This caused the Prep-event counter generator to not find any `Cmpt Prep` events and thus not creating the Counters.
As a side effect this causes massive potential overlap and often breaks the default overlap detection limit of 5.

The PR fixes the detection problem.