### PR TITLE
RCU Utilization Metric for Autopilot Enabled Traces

### DIFF
--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -191,8 +191,6 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
     _autopilot_pattern = re.compile(r'DSM-AutoPilot BEGIN')
     _iteration_mode_pattern = re.compile(r'^\s+(DECODING|PREFILL)\s+$')
     _total_pattern = re.compile(r'Total     ')
-    _non_kernel_names = ["Total"]
-
     _print_to_log = False
 
     def __init__(
@@ -309,26 +307,13 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
         else:
             return "Total"
 
-    def _get_autopilot(self, cl) -> None:
-
-        if self._autopilot_pattern.search(cl):
-            self.autopilot = True
-
-        else:
-            self.autopilot = False
-
     def _add_kernel(self,
                     kernel_and_cat: list[str],
                     cycles: int,
                     current_table: dict[str, int],
                     fprint: RCUTableFingerprint) -> RCUTableFingerprint:
         category = self._handle_category(kernel_and_cat)
-
-        if kernel_and_cat[0] != "supernode_kernel":
-            kernel = kernel_and_cat[0]+" Cmpt Exec"
-        else:
-            kernel = kernel_and_cat[0]
-
+        kernel = kernel_and_cat[0]+" Cmpt Exec"
         fprint.add(kernel, cycles * self.cycle_to_clock_factor)
 
         if kernel not in current_table:
@@ -358,10 +343,9 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
                                 dict[str, int],
                                 RCUTableFingerprint]:
 
-        # drop out if autopilot=1 is detected
-        #if self._autopilot_pattern.search(line):
-        #    self.autopilot = True
-        #    return False, parse_mode, current_table, fprint
+        if self._autopilot_pattern.search(line):
+            self.autopilot = True
+            return True, parse_mode, current_table, fprint
 
         if self._clock_scaling.search(line):
             aiulog.log(aiulog.WARN,
@@ -416,27 +400,19 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
             fprint = self._add_kernel(kernel_and_cat, total_cycles, current_table, fprint)
             return True, parse_mode, current_table, fprint
 
-        if self.autopilot:
+        ldata = re.split(" +", line)
+        if len(ldata) < 2 or len(ldata) > 3:  # strange format includes newline as a 3rd column
+            aiulog.log(
+                aiulog.WARN,
+                "UTL: found data pattern line with more than 2 columns. Check patterns.",
+                ldata)
             return True, parse_mode, current_table, fprint
 
-        if not self.autopilot:
-            ldata = re.split(" +", line)
-            if len(ldata) < 2 or len(ldata) > 3:  # strange format includes newline as a 3rd column
-                aiulog.log(
-                    aiulog.WARN,
-                    "UTL: found data pattern line with more than 2 columns. Check patterns.",
-                    ldata)
-                return True, parse_mode, current_table, fprint
+        cycles = int(ldata[1])
+        kernel_and_cat = self._category_splitter.split(ldata[0])
 
-            cycles = int(ldata[1])
-            kernel_and_cat = self._category_splitter.split(ldata[0])
-
-            # Skip anything that's not a kernel name
-            if kernel_and_cat[0] in self._non_kernel_names:
-                return True, parse_mode, current_table, fprint
-
-            fprint = self._add_kernel(kernel_and_cat, cycles, current_table, fprint)
-            return True, parse_mode, current_table, fprint
+        fprint = self._add_kernel(kernel_and_cat, cycles, current_table, fprint)
+        return True, parse_mode, current_table, fprint
 
     def extract_tables(self, compiler_log: str):
 
@@ -445,10 +421,6 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
         current_table = {}
         fprint = None  # fingerprints created when a new table is detected
         with open(compiler_log, 'r') as cl:
-
-            compiler_logs_content = cl.read()
-            self._get_autopilot(compiler_logs_content)
-            cl.seek(0)
 
             for line in cl:
                 (
@@ -567,7 +539,7 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
 
 class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool):
     _name_converter = re.compile(r"\[N\]")
-
+    _total_cycles_kernel_name = "Total Cmpt Exec"
     """
     Create a warning about uncertain table matching
     if similarity of a job fingerprint and 2 tables differs by less than this tolerance
@@ -615,6 +587,21 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
         # in single-log case: will turn everything into zero, otherwise use event rank
         self.rank_factor = 1 if self.multi_log else 0
 
+        # Start Timestamp of the Last Zero Utilization Event
+        self.last_zero_event_ts = 0.0
+
+        # Event PID of the Last Zero Utilization Event
+        self.last_zero_event_pid = 0
+
+        # Next Event Start Timestamp
+        self.next_event_ts = 0.0
+        
+        # Flag to keep track for event overlap
+        self.event_overlap = False
+
+        # Utilization Percentage of the previous event
+        self.last_event_utilization_percent = 0.0
+
         self.rcuctx: dict[int, RCUUtilizationContext] = {}
         for rank, log in enumerate(log_list):
             aiulog.log(aiulog.DEBUG, "UTL: Building kernel table for", rank)
@@ -636,7 +623,7 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
         rname = event["name"]
 
         if autopilot:
-            rname = "supernode_kernel"
+            rname = self._total_cycles_kernel_name
             return rname
 
         # if a fn_idx was removed from the event name, we have to bring it back in to match the ideal cycles table entry
@@ -665,19 +652,51 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
     def fingerprint_get(self, job: int) -> int:
         return self.fingerprints[job].get()
 
-    # build a counter and a zero event
+    # Build a counter and a zero event if there is no event overlap
     def make_utilization_event(self, event: TraceEvent, utilization: float) -> list[TraceEvent]:
-        revents = [{
+        self.event_overlap = False
+        revents = []
+
+        if self.last_zero_event_ts == 0.0:
+            self.next_event_ts = 0.0
+            self.last_zero_event_ts = event["ts"] + event["dur"]
+            self.last_event_utilization_percent = utilization
+            
+        # Check for event overlap
+        elif event["ts"] < self.last_zero_event_ts:
+            revents.append({
                 "ph": "C",
                 "ts": event["ts"],
+                "pid": event["pid"],
+                "name": RCU_pt_util_counter_name,
+                "args": {RCU_pt_util_counter_unit: self.last_event_utilization_percent if (self.last_event_utilization_percent > utilization) else utilization},
+                "dur": self.last_zero_event_ts - event["ts"]
+            })
+
+            self.next_event_ts = self.last_zero_event_ts
+            self.last_zero_event_ts = event["ts"] + event["dur"]
+            self.last_zero_event_pid = event["pid"]
+            self.event_overlap = True
+            self.last_event_utilization_percent = utilization
+
+        else:
+            self.next_event_ts = 0.0
+            self.last_event_utilization_percent = utilization
+
+        # Add the non-zero utilization event
+        revents = [{
+                "ph": "C",
+                "ts": event["ts"] if (self.next_event_ts == 0.0) else self.next_event_ts,
                 "pid": event["pid"],
                 "name": RCU_pt_util_counter_name,
                 "args": {RCU_pt_util_counter_unit: utilization},
                 "dur": event["dur"]  # temporary duration in cycles- remove before viz
             }]
-        if utilization > 0.0:   # add a reset-to-zero event only if util is non-zero
+        
+        # Add a reset-to-zero event only if the utilization is non-zero and if there is no event overlap
+        if utilization > 0.0 and (not self.event_overlap):
             revents.append({
-                "ph": "C",
+               "ph": "C",
                 "ts": event["ts"]+event["dur"],
                 "pid": event["pid"],
                 "name": RCU_pt_util_counter_name,
@@ -712,7 +731,19 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
     def drain(self) -> list[TraceEvent]:
         # run fingerprint-similarity check for all jobs
         self.update_fprint_matches()
-        return super().drain()
+
+        revents = super().drain()
+
+        # Add the last reset-to-zero event
+        if self.last_zero_event_ts:
+            revents.append({
+                "ph": "C",
+                    "ts": self.last_zero_event_ts,
+                    "pid": self.last_zero_event_pid,
+                    "name": RCU_pt_util_counter_name,
+                    "args": {RCU_pt_util_counter_unit: 0.0}
+                })
+        return revents
 
     def generate_fprint_jobhash(self, event: TraceEvent) -> int:
         jobhash = event["args"]["jobhash"]

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -190,6 +190,7 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
     _category_splitter = re.compile(r'(\-opCat|\-NA$)')
     _autopilot_pattern = re.compile(r'DSM-AutoPilot BEGIN')
     _iteration_mode_pattern = re.compile(r'^\s+(DECODING|PREFILL)\s+$')
+    _total_pattern = re.compile(r'Total     ')
     _non_kernel_names = ["Total"]
 
     _print_to_log = False
@@ -308,13 +309,26 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
         else:
             return "Total"
 
+    def _get_autopilot(self, cl) -> None:
+
+        if self._autopilot_pattern.search(cl):
+            self.autopilot = True
+
+        else:
+            self.autopilot = False
+
     def _add_kernel(self,
                     kernel_and_cat: list[str],
                     cycles: int,
                     current_table: dict[str, int],
                     fprint: RCUTableFingerprint) -> RCUTableFingerprint:
         category = self._handle_category(kernel_and_cat)
-        kernel = kernel_and_cat[0]+" Cmpt Exec"
+
+        if kernel_and_cat[0] != "supernode_kernel":
+            kernel = kernel_and_cat[0]+" Cmpt Exec"
+        else:
+            kernel = kernel_and_cat[0]
+
         fprint.add(kernel, cycles * self.cycle_to_clock_factor)
 
         if kernel not in current_table:
@@ -345,9 +359,9 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
                                 RCUTableFingerprint]:
 
         # drop out if autopilot=1 is detected
-        if self._autopilot_pattern.search(line):
-            self.autopilot = True
-            return False, parse_mode, current_table, fprint
+        #if self._autopilot_pattern.search(line):
+        #    self.autopilot = True
+        #    return False, parse_mode, current_table, fprint
 
         if self._clock_scaling.search(line):
             aiulog.log(aiulog.WARN,
@@ -384,23 +398,45 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
         if not self._data_pattern.search(line) or self._ignore_pattern.search(line):
             return True, parse_mode, current_table, fprint
 
-        ldata = re.split(" +", line)
-        if len(ldata) < 2 or len(ldata) > 3:  # strange format includes newline as a 3rd column
-            aiulog.log(
-                aiulog.WARN,
-                "UTL: found data pattern line with more than 2 columns. Check patterns.",
-                ldata)
+        # Adding the total cycles count with the mock kernel name "supernode_kernel"
+        # and self.autopilot
+        if self._total_pattern.search(line) and self.autopilot:
+            kernel_and_cat = re.split(" +", line)
+
+            if len(kernel_and_cat) < 2 or len(kernel_and_cat) > 3:  # strange format includes newline as a 3rd column
+                aiulog.log(
+                    aiulog.WARN,
+                    "UTL: found totalx` pattern line with more than 2 columns. Check patterns.",
+                    kernel_and_cat)
+                return True, parse_mode, current_table, fprint
+
+            total_cycles = int(kernel_and_cat[1])
+            kernel_and_cat[0] = "supernode_kernel"
+
+            fprint = self._add_kernel(kernel_and_cat, total_cycles, current_table, fprint)
             return True, parse_mode, current_table, fprint
 
-        cycles = int(ldata[1])
-        kernel_and_cat = self._category_splitter.split(ldata[0])
-
-        # Skip anything that's not a kernel name
-        if kernel_and_cat[0] in self._non_kernel_names:
+        if self.autopilot:
             return True, parse_mode, current_table, fprint
 
-        fprint = self._add_kernel(kernel_and_cat, cycles, current_table, fprint)
-        return True, parse_mode, current_table, fprint
+        if not self.autopilot:
+            ldata = re.split(" +", line)
+            if len(ldata) < 2 or len(ldata) > 3:  # strange format includes newline as a 3rd column
+                aiulog.log(
+                    aiulog.WARN,
+                    "UTL: found data pattern line with more than 2 columns. Check patterns.",
+                    ldata)
+                return True, parse_mode, current_table, fprint
+
+            cycles = int(ldata[1])
+            kernel_and_cat = self._category_splitter.split(ldata[0])
+
+            # Skip anything that's not a kernel name
+            if kernel_and_cat[0] in self._non_kernel_names:
+                return True, parse_mode, current_table, fprint
+
+            fprint = self._add_kernel(kernel_and_cat, cycles, current_table, fprint)
+            return True, parse_mode, current_table, fprint
 
     def extract_tables(self, compiler_log: str):
 
@@ -409,6 +445,11 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
         current_table = {}
         fprint = None  # fingerprints created when a new table is detected
         with open(compiler_log, 'r') as cl:
+
+            compiler_logs_content = cl.read()
+            self._get_autopilot(compiler_logs_content)
+            cl.seek(0)
+
             for line in cl:
                 (
                     keep_parsing,
@@ -591,8 +632,12 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
         for _, ctx in self.rcuctx.items():
             ctx.enable()
 
-    def extract_kernel_from_event_name(self, event: TraceEvent) -> str:
+    def extract_kernel_from_event_name(self, event: TraceEvent, autopilot : bool) -> str:
         rname = event["name"]
+
+        if autopilot:
+            rname = "supernode_kernel"
+            return rname
 
         # if a fn_idx was removed from the event name, we have to bring it back in to match the ideal cycles table entry
         if "[N]" in rname and "args" in event and "fn_idx" in event["args"]:
@@ -683,7 +728,10 @@ def compute_utilization_fingerprints(event: TraceEvent, context: AbstractContext
     assert isinstance(context, MultiRCUUtilizationContext)
 
     if PipelineContextTool.is_acc_event(event) and PipelineContextTool.is_acc_kernel(event):
-        kernel_name = context.extract_kernel_from_event_name(event)
+        pid = event["pid"]
+        rank = pid * context.rank_factor
+        autopilot = context.rcuctx[rank].autopilot
+        kernel_name = context.extract_kernel_from_event_name(event, autopilot)
 
         context.fingerprint_add(context.generate_fprint_jobhash(event), kernel_name, event["dur"])
     return [event]
@@ -699,7 +747,9 @@ def compute_utilization(event: TraceEvent, context: AbstractContext) -> list[Tra
         return [event]
 
     pid = event["pid"]
-    kernel_name = context.extract_kernel_from_event_name(event)
+    rank = pid * context.rank_factor
+    autopilot = context.rcuctx[rank].autopilot
+    kernel_name = context.extract_kernel_from_event_name(event, autopilot)
 
     try:
         jobhash = context.generate_fprint_jobhash(event)

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -128,7 +128,6 @@ class RCUTableFingerprint():
             f"{sim_val}  <- ({other.totaltime} / {self.totaltime} = {other.totaltime / self.totaltime})")
         return sim_val
 
-
 class RCUKernelCategoryMap():
     def __init__(self):
         self.kernel_cat_map: dict[str, str] = {"other": "other"}
@@ -151,7 +150,6 @@ class RCUKernelCategoryMap():
 
     def values(self):
         return self.kernel_cat_map.values()
-
 
 class RCUTableParseMode(Flag):
     ACTIVE_TABLE = auto()
@@ -595,8 +593,8 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
 
         # Next Event Start Timestamp
         self.next_event_ts = 0.0
-        
-        # Flag to keep track for event overlap
+
+        # Event overlap Status
         self.event_overlap = False
 
         # Utilization Percentage of the previous event
@@ -661,7 +659,7 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
             self.next_event_ts = 0.0
             self.last_zero_event_ts = event["ts"] + event["dur"]
             self.last_event_utilization_percent = utilization
-            
+ 
         # Check for event overlap
         elif event["ts"] < self.last_zero_event_ts:
             revents.append({
@@ -692,7 +690,7 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
                 "args": {RCU_pt_util_counter_unit: utilization},
                 "dur": event["dur"]  # temporary duration in cycles- remove before viz
             }]
-        
+
         # Add a reset-to-zero event only if the utilization is non-zero and if there is no event overlap
         if utilization > 0.0 and (not self.event_overlap):
             revents.append({

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -520,7 +520,7 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
 
 class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool):
     _name_converter = re.compile(r"\[N\]")
-    _total_cycles_kernel_name = "Total Cmpt Exec"
+    _total_cycles_kernel_name = "Total"
     """
     Create a warning about uncertain table matching
     if similarity of a job fingerprint and 2 tables differs by less than this tolerance
@@ -600,12 +600,13 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
         for _, ctx in self.rcuctx.items():
             ctx.enable()
 
-    def extract_kernel_from_event_name(self, event: TraceEvent, autopilot: bool) -> str:
+    def extract_kernel_from_event_name(self, event: TraceEvent) -> str:
         rname = event["name"]
+        rank = event["pid"] * self.rank_factor
+        autopilot = self.rcuctx[rank].autopilot
 
         if autopilot:
             rname = self._total_cycles_kernel_name
-            return rname
 
         # if a fn_idx was removed from the event name, we have to bring it back in to match the ideal cycles table entry
         if "[N]" in rname and "args" in event and "fn_idx" in event["args"]:
@@ -667,14 +668,14 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
             self.last_event_utilization_percent = utilization
 
         # Add the non-zero utilization event
-        revents = [{
+        revents.append({
                 "ph": "C",
                 "ts": event["ts"] if (self.next_event_ts == 0.0) else self.next_event_ts,
                 "pid": event["pid"],
                 "name": RCU_pt_util_counter_name,
                 "args": {RCU_pt_util_counter_unit: utilization},
                 "dur": event["dur"]  # temporary duration in cycles- remove before viz
-            }]
+            })
 
         # Add a reset-to-zero event only if the utilization is non-zero and if there is no event overlap
         if utilization > 0.0 and (not self.event_overlap):
@@ -742,10 +743,7 @@ def compute_utilization_fingerprints(event: TraceEvent, context: AbstractContext
     assert isinstance(context, MultiRCUUtilizationContext)
 
     if PipelineContextTool.is_acc_event(event) and PipelineContextTool.is_acc_kernel(event):
-        pid = event["pid"]
-        rank = pid * context.rank_factor
-        autopilot = context.rcuctx[rank].autopilot
-        kernel_name = context.extract_kernel_from_event_name(event, autopilot)
+        kernel_name = context.extract_kernel_from_event_name(event)
 
         context.fingerprint_add(context.generate_fprint_jobhash(event), kernel_name, event["dur"])
     return [event]
@@ -761,9 +759,7 @@ def compute_utilization(event: TraceEvent, context: AbstractContext) -> list[Tra
         return [event]
 
     pid = event["pid"]
-    rank = pid * context.rank_factor
-    autopilot = context.rcuctx[rank].autopilot
-    kernel_name = context.extract_kernel_from_event_name(event, autopilot)
+    kernel_name = context.extract_kernel_from_event_name(event)
 
     try:
         jobhash = context.generate_fprint_jobhash(event)

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -128,6 +128,7 @@ class RCUTableFingerprint():
             f"{sim_val}  <- ({other.totaltime} / {self.totaltime} = {other.totaltime / self.totaltime})")
         return sim_val
 
+
 class RCUKernelCategoryMap():
     def __init__(self):
         self.kernel_cat_map: dict[str, str] = {"other": "other"}
@@ -150,6 +151,7 @@ class RCUKernelCategoryMap():
 
     def values(self):
         return self.kernel_cat_map.values()
+
 
 class RCUTableParseMode(Flag):
     ACTIVE_TABLE = auto()
@@ -617,7 +619,7 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
         for _, ctx in self.rcuctx.items():
             ctx.enable()
 
-    def extract_kernel_from_event_name(self, event: TraceEvent, autopilot : bool) -> str:
+    def extract_kernel_from_event_name(self, event: TraceEvent, autopilot: bool) -> str:
         rname = event["name"]
 
         if autopilot:
@@ -659,7 +661,7 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
             self.next_event_ts = 0.0
             self.last_zero_event_ts = event["ts"] + event["dur"]
             self.last_event_utilization_percent = utilization
- 
+
         # Check for event overlap
         elif event["ts"] < self.last_zero_event_ts:
             revents.append({
@@ -667,7 +669,9 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
                 "ts": event["ts"],
                 "pid": event["pid"],
                 "name": RCU_pt_util_counter_name,
-                "args": {RCU_pt_util_counter_unit: self.last_event_utilization_percent if (self.last_event_utilization_percent > utilization) else utilization},
+                "args": {RCU_pt_util_counter_unit:
+                         self.last_event_utilization_percent
+                         if (self.last_event_utilization_percent > utilization) else utilization},
                 "dur": self.last_zero_event_ts - event["ts"]
             })
 
@@ -694,7 +698,7 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
         # Add a reset-to-zero event only if the utilization is non-zero and if there is no event overlap
         if utilization > 0.0 and (not self.event_overlap):
             revents.append({
-               "ph": "C",
+                "ph": "C",
                 "ts": event["ts"]+event["dur"],
                 "pid": event["pid"],
                 "name": RCU_pt_util_counter_name,
@@ -736,10 +740,10 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
         if self.last_zero_event_ts:
             revents.append({
                 "ph": "C",
-                    "ts": self.last_zero_event_ts,
-                    "pid": self.last_zero_event_pid,
-                    "name": RCU_pt_util_counter_name,
-                    "args": {RCU_pt_util_counter_unit: 0.0}
+                "ts": self.last_zero_event_ts,
+                "pid": self.last_zero_event_pid,
+                "name": RCU_pt_util_counter_name,
+                "args": {RCU_pt_util_counter_unit: 0.0}
                 })
         return revents
 

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -190,7 +190,6 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
     _category_splitter = re.compile(r'(\-opCat|\-NA$)')
     _autopilot_pattern = re.compile(r'DSM-AutoPilot BEGIN')
     _iteration_mode_pattern = re.compile(r'^\s+(DECODING|PREFILL)\s+$')
-    _total_pattern = re.compile(r'Total     ')
     _print_to_log = False
 
     def __init__(
@@ -380,24 +379,6 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
 
         # This will need to be the last regex check because it skips everything else
         if not self._data_pattern.search(line) or self._ignore_pattern.search(line):
-            return True, parse_mode, current_table, fprint
-
-        # Adding the total cycles count with the mock kernel name "supernode_kernel"
-        # and self.autopilot
-        if self._total_pattern.search(line) and self.autopilot:
-            kernel_and_cat = re.split(" +", line)
-
-            if len(kernel_and_cat) < 2 or len(kernel_and_cat) > 3:  # strange format includes newline as a 3rd column
-                aiulog.log(
-                    aiulog.WARN,
-                    "UTL: found totalx` pattern line with more than 2 columns. Check patterns.",
-                    kernel_and_cat)
-                return True, parse_mode, current_table, fprint
-
-            total_cycles = int(kernel_and_cat[1])
-            kernel_and_cat[0] = "supernode_kernel"
-
-            fprint = self._add_kernel(kernel_and_cat, total_cycles, current_table, fprint)
             return True, parse_mode, current_table, fprint
 
         ldata = re.split(" +", line)
@@ -657,7 +638,7 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
         self.event_overlap = False
         revents = []
 
-        if self.last_zero_event_ts == 0.0:
+        if isclose(self.last_zero_event_ts, 0.0, abs_tol=1e-9):
             self.next_event_ts = 0.0
             self.last_zero_event_ts = event["ts"] + event["dur"]
             self.last_event_utilization_percent = utilization
@@ -737,7 +718,7 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
         revents = super().drain()
 
         # Add the last reset-to-zero event
-        if self.last_zero_event_ts:
+        if self.last_zero_event_ts > 0.0:
             revents.append({
                 "ph": "C",
                 "ts": self.last_zero_event_ts,

--- a/tests/aiu_trace_analyzer/pipeline/test_rcu_utilization.py
+++ b/tests/aiu_trace_analyzer/pipeline/test_rcu_utilization.py
@@ -59,7 +59,8 @@ expected_vars_and_values = [
      {"somevalue":
       {'addmm_MatMul-BMM_1 Cmpt Exec': 27648,
        'addmm_1_MatMul-BMM_1 Cmpt Exec': 27648,
-       'bmm-BMM_1 Cmpt Exec': 12288
+       'bmm-BMM_1 Cmpt Exec': 12288,
+       'Total Cmpt Exec' : 67584,
        }
       }
      )

--- a/tests/aiu_trace_analyzer/pipeline/test_rcu_utilization.py
+++ b/tests/aiu_trace_analyzer/pipeline/test_rcu_utilization.py
@@ -60,7 +60,7 @@ expected_vars_and_values = [
       {'addmm_MatMul-BMM_1 Cmpt Exec': 27648,
        'addmm_1_MatMul-BMM_1 Cmpt Exec': 27648,
        'bmm-BMM_1 Cmpt Exec': 12288,
-       'Total Cmpt Exec' : 67584,
+       'Total Cmpt Exec': 67584,
        }
       }
      )


### PR DESCRIPTION
Enabling the RCU Utilization Metric for autopilot enabled torch profiler traces specifically in the case of single AIU and workloads generating single ideal cycles table. Total Ideal Cycles information is collected from the compiler logs and stored in the kernel cycles map with the name 'Total Cmpt Exec'. The PR also fixes the issue of the utilization counter being messed up when two events overlap.

Note : Overlapping Events indicate an issue with the timestamps and a high chance that the trace file is broken which needs to be handled separately.