### PR TITLE
example/template to create a verification pipeline

### DIFF
--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -116,7 +116,11 @@ class Acelyzer:
             "ts_start": 0.0,
             "ts_end": sys.float_info.max,
             "no_count_types": "M",
-        }
+        },
+
+        # by default use regular (or provided) stage processing profile and not verification mode
+        "verification_mode": False,
+        "verification_profile": os.path.join(os.path.dirname(__file__), "../profiles/verification.json"),
     }
 
     # define default event sort key: timestamp + reverse_duration
@@ -130,14 +134,14 @@ class Acelyzer:
                 print(__version__)
                 sys.exit(0)
 
+            aiulog.loglevel = self.args.loglevel
+            aiulog.log(aiulog.INFO, "Starting Test parser")
+
             if not self._args_sanity_check(self.args):
                 sys.exit(1)
         except Exception as e:
             print(e)
             sys.exit(1)
-
-        aiulog.loglevel = self.args.loglevel
-        aiulog.log(aiulog.INFO, "Starting Test parser")
 
         self.freq_soc = self.args.freq[0]
         self.freq_core = self.args.freq[1]
@@ -153,7 +157,9 @@ class Acelyzer:
             importer = ingest.MultifileIngest(
                 source_uri=self.args.input,
                 show_warnings=(not self.args.disable_input_warnings),
-                direct_data=self.direct_data)
+                direct_data=self.direct_data,
+                verification_mode=self.args.verification_mode
+            )
         except FileNotFoundError:
             sys.exit(1)
 
@@ -188,7 +194,10 @@ class Acelyzer:
                 return -1
         self.exporter.export_meta(importer.get_passthrough_meta())
 
-        self.register_processing_functions(process, self.args, self.exporter)
+        if not self.args.verification_mode:
+            self.register_processing_functions(process, self.args, self.exporter)
+        else:
+            self.register_verification_functions(process, args=self.args, exporter=self.exporter)
 
         # create main engine and run
         dr = engine.Engine(importer, process, self.exporter)
@@ -354,6 +363,10 @@ class Acelyzer:
                             default=self.defaults["sync_to_dev"],
                             help="When set, use epoch from device timers")
 
+        parser.add_argument("-V", "--verify", dest="verification_mode", action="store_const", const=True,
+                            default=self.defaults["verification_mode"],
+                            help="When set, switch to file verification mode with almost no modifications.")
+
         parser.add_argument("--autopilot_data", type=str, default=self.defaults["autopilot_db"],
                             help="(Not yet implemented) Where to look for kernel category data"
                             " from runs with 'autopilot=0'.")
@@ -434,6 +447,9 @@ class Acelyzer:
             else:
                 parsed_args.profile = self.defaults["stage_profile"]
 
+        if parsed_args.verification_mode:
+            parsed_args.profile = self.defaults["verification_profile"]
+
         return parsed_args
 
     def get_output_data(self):
@@ -455,6 +471,9 @@ class Acelyzer:
                                         " directory path provided. No utilization will be plotted.")
             elif not os.path.exists(args.compiler_info):
                 aiulog.log(aiulog.WARN, "Invalid directory path provided. No utilization will be plotted.")
+
+        if args.verification_mode:
+            aiulog.log(aiulog.INFO, "Running VERIFICATION MODE! Using stage profile: ", args.profile)
 
         return True
 
@@ -725,3 +744,12 @@ class Acelyzer:
         process.register_stage(callback=event_pipe.sort_events, context=final_sort_ctx)
 
         # <<< END Event processing functions registration
+
+    def register_verification_functions(self,
+                                        process: processor.EventProcessor,
+                                        args,
+                                        exporter: output.AbstractTraceExporter):
+        verification_ctx = event_pipe.VerificationContext()
+
+        process.register_stage(callback=event_pipe.verify, context=verification_ctx)
+        process.register_stage(callback=event_pipe.verify_cleanup)

--- a/src/aiu_trace_analyzer/core/stage_profile.py
+++ b/src/aiu_trace_analyzer/core/stage_profile.py
@@ -35,6 +35,9 @@ class StageProfile:
         if 'stages' not in profile_data:
             raise KeyError("Profile data is missing 'stages' key.")
 
+        if len(profile_data['stages']) == 0:
+            return []
+
         # walk the full list and pick up the enabled/disabled flag from the requested config
         next_stage, next_enabled = profile_data['stages'].pop(0).popitem()
         profile: list[tuple[str, bool]] = []

--- a/src/aiu_trace_analyzer/ingest/ingestion.py
+++ b/src/aiu_trace_analyzer/ingest/ingestion.py
@@ -35,7 +35,8 @@ class AbstractTraceIngest:
             jobdata: GlobalIngestData = GlobalIngestData(),
             data_dialect: InputDialect = InputDialectTORCH(),
             scale: float = 1.0,
-            show_warnings: bool = True) -> None:
+            show_warnings: bool = True,
+            verification_mode: bool = False) -> None:
         self.source_uri = source_uri
         self.scale = scale
         self.ts_offset = None
@@ -52,6 +53,7 @@ class AbstractTraceIngest:
                 text="Ingestion: detected negative duration event(s). Events ignored:{d[count]}",
                 data={"count": 0})
         }
+        self.verification_mode = verification_mode
         self._initialized = False
         self.other_metadata = {}
         self.jobhash = jobdata.add_job_info(source_uri, data_dialect)
@@ -196,8 +198,20 @@ class AbstractTraceIngest:
             event[the_args]["jobhash"] = self.jobhash
         return event
 
+    def _detect_args_type(self, event: TraceEvent) -> str:
+        if "attr" in event:
+            return "attr"
+        else:
+            return "args"
+
     # update event data with things like ts-offset or ts-scaling
     def updated_event(self, event: TraceEvent) -> TraceEvent:
+        the_args = self._detect_args_type(event)
+        if self.verification_mode:
+            if the_args in event:
+                event = self._add_job_hash(event, the_args)
+            return event
+
         if event["ph"] not in "XBE":
             if event["ph"] in "Mbei":
                 event = self._rank_device_annotation(event, "args")
@@ -208,9 +222,6 @@ class AbstractTraceIngest:
         if "dur" in event:
             event["dur"] = float(event["dur"] * self.scale)
 
-        the_args = "args"
-        if "attr" in event:
-            the_args = "attr"
         if the_args not in event:
             event[the_args] = {}
 
@@ -238,12 +249,14 @@ class JsonEventTraceIngest(AbstractTraceIngest):
             data_dialect: InputDialect,
             scale: float = 1.0,
             keep_processed: bool = False,
-            show_warnings: bool = True) -> None:
+            show_warnings: bool = True,
+            verification_mode: bool = False) -> None:
         super().__init__(source_uri,
                          jobdata=jobdata,
                          data_dialect=data_dialect,
                          scale=scale,
-                         show_warnings=show_warnings)
+                         show_warnings=show_warnings,
+                         verification_mode=verification_mode)
 
         self.data: dict = {}
         self.last_ts: float = 0.0
@@ -382,12 +395,20 @@ class MemoryJsonTraceIngest(JsonEventTraceIngest):
             jobdata: GlobalIngestData = GlobalIngestData(),
             scale: float = 1.0,
             show_warnings: bool = True,
-            direct_data: memoryview = None):
+            direct_data: memoryview = None,
+            verification_mode: bool = False):
         keep_processed = True
         data = json.loads(direct_data.tobytes())
 
         data_dialect = InputDialectTORCH() if self.is_torch_profile(data) else InputDialectFLEX()
-        super().__init__(source_uri, jobdata, data_dialect, scale, keep_processed, show_warnings)
+        super().__init__(
+            source_uri,
+            jobdata,
+            data_dialect,
+            scale,
+            keep_processed,
+            show_warnings,
+            verification_mode=verification_mode)
 
         self._initialize_data(data)
 
@@ -402,13 +423,21 @@ class JsonFileEventTraceIngest(JsonEventTraceIngest):
             jobdata: GlobalIngestData = GlobalIngestData(),
             scale: float = 1.0,
             keep_processed: bool = False,
-            show_warnings: bool = True):
+            show_warnings: bool = True,
+            verification_mode: bool = False):
 
         with open(source_uri, 'r') as sourcefile:
             data = json.load(sourcefile)
 
         data_dialect = InputDialectTORCH() if self.is_torch_profile(data) else InputDialectFLEX()
-        super().__init__(source_uri, jobdata, data_dialect, scale, keep_processed, show_warnings)
+        super().__init__(
+            source_uri,
+            jobdata,
+            data_dialect,
+            scale,
+            keep_processed,
+            show_warnings,
+            verification_mode=verification_mode)
 
         self._initialize_data(data)
 
@@ -504,8 +533,16 @@ class MultifileIngest(AbstractTraceIngest):
     Performs a round-robin over all files
     and skips any iterators that are exhausted.
     '''
-    def __init__(self, source_uri, show_warnings: bool = True, direct_data: memoryview = None) -> None:
-        super().__init__("top_level_multifile", show_warnings=show_warnings)
+    def __init__(
+            self,
+            source_uri,
+            show_warnings: bool = True,
+            direct_data: memoryview = None,
+            verification_mode: bool = False) -> None:
+        super().__init__(
+            "top_level_multifile",
+            show_warnings=show_warnings,
+            verification_mode=verification_mode)
 
         self.split_pattern = re.compile(r"[,\s]")
         filelist = self.generate_filelist(source_uri)
@@ -525,13 +562,18 @@ class MultifileIngest(AbstractTraceIngest):
         _added_new = True
         self.ftype = self.detect_ftype(ingest)
         if self.ftype == self.FTYPE_JSON:
-            self.ingesters.append(JsonFileEventTraceIngest(ingest, show_warnings=self.show_warnings))
+            self.ingesters.append(JsonFileEventTraceIngest(
+                ingest,
+                show_warnings=self.show_warnings,
+                verification_mode=self.verification_mode))
         elif self.ftype == self.FTYPE_PFTRACE:
             self.ingesters.append(ProtobufIngest(ingest))
         elif self.ftype == self.FTYPE_API:
-            self.ingesters.append(
-                MemoryJsonTraceIngest(ingest, show_warnings=self.show_warnings, direct_data=self.direct_data)
-            )
+            self.ingesters.append(MemoryJsonTraceIngest(
+                ingest,
+                show_warnings=self.show_warnings,
+                direct_data=self.direct_data,
+                verification_mode=self.verification_mode))
         else:
             aiulog.log(aiulog.ERROR, "Unrecognized file type. file:", ingest)
             _added_new = False

--- a/src/aiu_trace_analyzer/ingest/ingestion.py
+++ b/src/aiu_trace_analyzer/ingest/ingestion.py
@@ -189,6 +189,9 @@ class AbstractTraceIngest:
                 event[the_args]["otid"] = event["tid"]
                 event["tid"] = hash(event["tid"])
 
+        return event
+
+    def _add_job_hash(self, event: TraceEvent, the_args: str) -> TraceEvent:
         if event["ph"] not in ["F", "f", "s", "t", "C", "M"]:
             event[the_args]["jobhash"] = self.jobhash
         return event
@@ -214,6 +217,7 @@ class AbstractTraceIngest:
         event = self._rank_device_annotation(event, the_args)
         event = self._pid_correction(event, the_args)
         event = self._tid_correction(event, the_args)
+        event = self._add_job_hash(event, the_args)
         return event
 
 

--- a/src/aiu_trace_analyzer/pipeline/__init__.py
+++ b/src/aiu_trace_analyzer/pipeline/__init__.py
@@ -110,3 +110,6 @@ from aiu_trace_analyzer.pipeline.categorize import event_categorizer, event_cate
 
 # for reference of the template, you'd do here:
 #       from aiu_trace_analyzer.pipeline.template import myprocessing
+
+from aiu_trace_analyzer.verification.verify import verify, verify_cleanup
+from aiu_trace_analyzer.verification.verify import VerificationContext

--- a/src/aiu_trace_analyzer/profiles/everything.json
+++ b/src/aiu_trace_analyzer/profiles/everything.json
@@ -56,6 +56,8 @@
         {"tb_refinement_lightweight": true},
         {"cycle_count_conversion_cleanup": true},
         {"calculate_stats_v2": true},
-        {"sort_events": true}
+        {"sort_events": true},
+        {"verify": true},
+        {"verify_cleanup": true}
     ]
 }

--- a/src/aiu_trace_analyzer/profiles/verification.json
+++ b/src/aiu_trace_analyzer/profiles/verification.json
@@ -1,0 +1,6 @@
+{
+    "stages": [
+        {"verify": true},
+        {"verify_cleanup": true}
+    ]
+}

--- a/src/aiu_trace_analyzer/verification/verify.py
+++ b/src/aiu_trace_analyzer/verification/verify.py
@@ -1,0 +1,176 @@
+# Copyright 2024-2026 IBM Corporation
+
+"""
+Verification module for AIU trace events - EXAMPLE/TEMPLATE.
+
+This module serves as an educational example and template for implementing
+trace event verification in the AIU trace analyzer pipeline. It demonstrates:
+- How to create a custom context class extending AbstractContext
+- How to implement event verification logic
+- How to track warnings and collect statistics
+- How to create pipeline-compatible functions
+
+For additional details how to integrate into the pipeline, see '../pipeline/template.py'
+
+The verification logic here is intentionally simple (checking event phase types)
+to serve as a learning reference. Real verification implementations should be
+adapted based on specific trace analysis requirements.
+"""
+
+import aiu_trace_analyzer.logger as aiulog
+
+from aiu_trace_analyzer.types import TraceEvent
+from aiu_trace_analyzer.pipeline.context import AbstractContext
+from aiu_trace_analyzer.types import TraceWarning
+
+
+class VerificationContext(AbstractContext):
+    """
+    EXAMPLE: Context class for managing trace event verification state.
+
+    This serves as a template demonstrating how to create a custom context
+    for trace analysis. It shows how to:
+    - Extend AbstractContext, TwoPhaseWithBarrierContext or other abstract
+      support classes for pipeline integration
+    - Initialize and track warnings
+    - Collect statistics during event processing
+
+    This example tracks verification failures and collects event types
+    encountered during trace processing.
+
+    Attributes:
+        _FWARN_KEY (str): Key for accessing the failed verification warning.
+        type_collect (set): Set of unique event phase types encountered.
+    """
+
+    _FWARN_KEY = "failed_verification"
+
+    def __init__(self, warnings: list[TraceWarning] = None) -> None:
+        """
+        Initialize the verification context - EXAMPLE IMPLEMENTATION.
+
+        This demonstrates how to set up a context with custom warnings.
+        The warning is configured with a template message that uses data
+        placeholders for dynamic values.
+
+        Args:
+            warnings: Optional list of additional warnings to track.
+        """
+        super().__init__(warnings=[
+            TraceWarning(
+                name=self._FWARN_KEY,
+                text="VRF: Encountered {d[count]} Events that failed verification",
+                data={"count": 0},
+                is_error=True,
+            )]
+        )
+        # Initialize set to collect unique event phase types encountered while processing
+        self.type_collect = set([])
+
+    def event_verification(self, event: TraceEvent) -> bool:
+        """
+        EXAMPLE: Verify a trace event meets expected criteria.
+
+        This is a simple example verification that checks event phase types.
+        Real implementations should include more sophisticated validation
+        based on specific trace requirements (e.g., timestamp ordering,
+        required fields, value ranges, etc.).
+
+        This example collects the event's phase type and checks if it's one
+        of the valid phase types (X, B, E, b, e). Events with invalid phase
+        types are counted as verification failures. The list is intentionally
+        made incomplete to demonstrate how verification can fail.
+
+        Args:
+            event: The trace event to verify.
+
+        Returns:
+            bool: True if the event passes verification, False otherwise.
+                  Return values are not required depending on your use case.
+        """
+        # Collect the event phase type for analysis
+        self.type_collect.add(event["ph"])
+
+        # Verify event phase type is one of the expected types:
+        # X: Complete event, B: Begin event, E: End event, b: Nested begin, e: Nested end
+        if event["ph"] not in "XBEbe":
+            self.warnings[self._FWARN_KEY].update()
+            return False
+        return True
+
+    def drain(self) -> list[TraceEvent]:
+        """
+        EXAMPLE: Finalize verification and log collected event types.
+
+        This demonstrates how to implement cleanup/finalization logic in a
+        context. The drain() method is called at the end of trace processing
+        and is useful for logging summaries, finalizing statistics, or
+        performing any end-of-processing tasks.
+
+        Returns:
+            list[TraceEvent]: Empty list from parent drain() method. May also return
+                              a list of events that have been held back during processing
+        """
+        aiulog.log(aiulog.INFO, "VRF: found types:", self.type_collect)
+        return super().drain()
+
+
+def verify(event: TraceEvent, ctx: AbstractContext, _cfg: dict = None) -> list[TraceEvent]:
+    """
+    EXAMPLE: Pipeline function to verify a trace event.
+
+    This demonstrates the standard signature for pipeline functions:
+    - Takes an event, context, and optional config
+    - Returns a list of events (allows filtering, splitting, or passing through)
+    - Uses assertions to validate context type
+
+    This example delegates verification to the VerificationContext and passes
+    the event through unchanged. Real implementations might filter out invalid
+    events or modify them based on verification results.
+
+    Args:
+        event: The trace event to verify.
+        ctx: The context object, must be a VerificationContext instance.
+        _cfg: Optional configuration dictionary (unused in this example).
+
+    Returns:
+        list[TraceEvent]: Single-element list containing the input event.
+
+    Raises:
+        AssertionError: If ctx is not a VerificationContext instance.
+    """
+    assert isinstance(ctx, VerificationContext), "context must be of type VerificationContext"
+    ctx.event_verification(event)
+    return [event]
+
+
+def verify_cleanup(event: TraceEvent, _ctx: AbstractContext = None, _cfg: dict = None) -> list[TraceEvent]:
+    """
+    EXAMPLE: Clean up trace event by removing ingestion artifacts.
+
+    This demonstrates a simple cleanup/transformation pipeline function.
+    It shows how to:
+    - Modify event data in-place
+    - Handle optional fields safely
+    - Work with different field name conventions
+
+    This example removes the 'jobhash' field that may have been added during
+    trace ingestion. Real cleanup functions might normalize timestamps,
+    remove debug fields, or standardize event formats.
+
+    Args:
+        event: The trace event to clean up.
+        _ctx: Optional context object (unused in this example).
+        _cfg: Optional configuration dictionary (unused in this example).
+
+    Returns:
+        list[TraceEvent]: Single-element list containing the cleaned event.
+    """
+    # Determine which field name is used for event arguments
+    # Some events use 'args', others use 'attr' (used by FLEX trace files)
+    the_args = "args" if "attr" not in event else "attr"
+
+    # Remove jobhash if it exists in the event's arguments
+    if the_args in event and "jobhash" in event[the_args]:
+        del event[the_args]["jobhash"]
+    return [event]


### PR DESCRIPTION
Adding a `-V` cmdline option to `acelyzer` to switch from post processing to data verification mode.

It's establishing a separate kind of pipeline with minimal changes to the input events so that the trace file data can be checked in various ways.

Changes to most files help enable/implement the verification mode.

`src/aiu_trace_analyzer/verification/verify.py` contains a documented example how that could look like.
Running:
```
acelyzer -i <inputfile> -o <outputfile> -V
```

looks like:
```
2026-04-09T16:17:21.994465     INFO Starting Test parser 
2026-04-09T16:17:21.994518     INFO Running VERIFICATION MODE! Using stage profile:  ../profiles/verification.json 
2026-04-09T16:17:21.994657     INFO Reading files: [<input file list>] 
2026-04-09T16:17:21.994665     INFO Ingesting 1 files. 
2026-04-09T16:17:24.733389     INFO VRF: found types: {'M', 'i', 'X', 'f', 's'} 
2026-04-09T16:17:24.733443    ERROR VRF: Encountered 226753 Events that failed verification 
2026-04-09T16:17:27.934500     INFO Finishing Test parser. Return code= 0 
2026-04-09T16:17:27.934542     INFO Exported events:  512842 
```

Note the actual verification in this example is obviously bogus: checking the event type and failing if it's not listed. It's intentionally made to fail to show the effect. And it's intentionally made simple to serve as a template.
