### PR TITLE
Maintenance 26 week 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+# v1.2.0
+
+## Enhancements
+- Added RCU utilization support for autopilot-enabled traces.
+- Extended PT-active signal creation to multi-AIU and multi-table traces.
+- Added time-weighted power statistics analysis.
+- Added Pandas dataframe export support.
+- Improved event classification for more detailed trace categorization.
+- Added flow events for kernel launch/completion and improved collective flow handling.
+- Added configurable event limiting and maximum TID streams for overlap resolution.
+- Improved timestamp refinement based on hardware timing.
+
+## Bug Fixes
+- Fixed RCU utilization handling for the torch spyre stack.
+- Fixed pre-event parsing for queuing counter creation.
+- Fixed rank info, process ordering, and deviceProperties ingestion for multi-process torch traces.
+- Relaxed classifier mismatches to accumulated warnings.
+- Skip launch-flow event creation when inconsistent timestamps are detected.
+- Gracefully handle zero-gap events during frequency estimation.
+- Removed the obsolete time_align stage now that torch+flex alignment is no longer needed.
+
+## Contributions to this release from
+- lasch
+- yuhaohaoyu
+- WarningRan
+- aishwariyachakraborty
+- aryanputta
+- tej7499
+
+## Code Quality
+- Replaced hardcoded package versioning with git-tag-based versioning.
+- Disabled warnings from deactivated stages.
+- Added and updated unit tests across core processing paths.
+- Added SonarQube configuration and tightened CI formatting checks.
+- Applied general maintenance updates and fixes.
+
 # v1.0.2
  - requires Python 3.10 or later (3.9 is out of support)
 

--- a/README.md
+++ b/README.md
@@ -138,8 +138,51 @@ When running `acelyzer`, the progress and basic processing information is printe
 This section explains some of the command line options in more detail.
 
 
-### compiler_log
-This option allows to pass the compiler log output into `acelyzer` and allows for additional data augmentation and PT-Array utilization data. For multi-AIU workloads, one file per process should be provided to avoid intermingled data inside the log. Also it is important that multi-AIU logfiles be provided in the order of the process ranks to properly map each log file to its rank.
+### compiler_info
+This option allows to pass the compiler log output file or directory into `acelyzer` and allows for additional data augmentation and PT-Array utilization data. For multi-AIU workloads, one file per process should be provided to avoid intermingled data inside the log. Also it is important that multi-AIU logfiles be provided in the order of the process ranks to properly map each log file to its rank.
+
+
+### event_filter
+Allows to specify a regex to remove events from the processing. This is useful to either remove events that are not of interest or to remove events that cause problems processing the input.
+
+
+### event_limit
+This enables working with very large input data. It allows to limit the number of events that are processed by limiting the timestamp range or the number of events.
+
+
+### freq
+
+This option allows to set the SoC and Ideal frequencies if they differ from the default.
+Right now, we're not scanning a potential log file for this data and thus rely on the user to provide the information.
+ * *SoC* frequency is setting the frequency that was used for the cycle counter in the flex events. It is essential to get it at least roughly correct to prevent misaligned AIU-CPU events.
+ * *core* frequency is setting the frequency that was used to calculate the *ideal cycles* that is placed in the compiler log file.  This value is used to compute the utilization of the core PT array by compute kernels that have a non-zero value. If it is not matching the core frequency, it causes the PT array utilization to be miscalculated or cause errors when utilization of >100% is the result of a too-low frequency.
+
+If acelyzer detects a consistent effective frequency for events, it will provide a suggestion like:
+```
+<timestamp>  WARNING  FREQ: Recommendation: to minimize event time drift (max: -333833us) between CPU and Accelerator, use: --freq=899.577
+```
+This suggestion will only appear for drift between jobs and thus requires at least 2 jobs at the input.
+
+An additional set of frequency statistics computes min/mean/max observed frequencies based on individual event duration and event intervals between subsequent compute events.  Therefore, it's working for single-job flex traces too.  The corresponding output looks like this:
+```
+<timestamp>  WARNING FREQ: Detected Event-duration-based frequency (min/mean/max): <x> <y> <z> ; rel_range=0.023, input_soc_freq/detected=2.08
+<timestamp>  WARNING FREQ: Detected Event-interval-based frequency (min/mean/max): <x> <y> <z> ; rel_range=0.012, input_soc_freq/detected=2.09
+```
+The `rel_range` number shows how narrow/wide the window of detected frequencies was.
+A narrow window indicates consistent trace data with well-calibrated cycle-to-clock conversion.
+The ratio of `input_soc_freq/detected` helps to determine whether the soc-freq setting on the cmdline was reasonably close to the reality of this trace.
+In best case, the relative range should be close to 0.0 and the input/detect-ratio is expected to be close to 1.0.
+
+Consequences when in use:
+ * see [here](#understanding-and-troubleshooting-the-results) for various problems that can be caused or alleviated by this parameter
+
+
+### overlap
+
+A lot of things are asynchronously processed and the corresponding events are not possible to view as a proper call stack in either of the 2 viewers (chrome, perfetto). The tool provides 3 options via `-O nnn` argument to resolve situations where events overlap in that way:
+ 1) increase the thread ID to separate `tid` (default, recommended)
+ 2) drop conflicting events `drop` (intended for debugging and not recommended)
+ 3) convert some events into asynchronous events `async` (deprecated, incomplete implementation of subsequent processing stages and thus not recommended to use)
 
 
 ### flow
@@ -188,44 +231,9 @@ Consequences when in use:
  * spans the entire time from posting of the communication to the completion, this can exaggerate communication time e.g. if a recv is posted early for later completion
 
 
-### freq
-
-This option allows to set the SoC and Ideal frequencies if they differ from the default.
-Right now, we're not scanning a potential log file for this data and thus rely on the user to provide the information.
- * *SoC* frequency is setting the frequency that was used for the cycle counter in the flex events. It is essential to get it at least roughly correct to prevent misaligned AIU-CPU events.
- * *core* frequency is setting the frequency that was used to calculate the *ideal cycles* that is placed in the compiler log file.  This value is used to compute the utilization of the core PT array by compute kernels that have a non-zero value. If it is not matching the core frequency, it causes the PT array utilization to be miscalculated or cause errors when utilization of >100% is the result of a too-low frequency.
-
-If acelyzer detects a consistent effective frequency for events, it will provide a suggestion like:
-```
-<timestamp>  WARNING  FREQ: Recommendation: to minimize event time drift (max: -333833us) between CPU and Accelerator, use: --freq=899.577
-```
-This suggestion will only appear for drift between jobs and thus requires at least 2 jobs at the input.
-
-An additional set of frequency statistics computes min/mean/max observed frequencies based on individual event duration and event intervals between subsequent compute events.  Therefore, it's working for single-job flex traces too.  The corresponding output looks like this:
-```
-<timestamp>  WARNING FREQ: Detected Event-duration-based frequency (min/mean/max): <x> <y> <z> ; rel_range=0.023, input_soc_freq/detected=2.08
-<timestamp>  WARNING FREQ: Detected Event-interval-based frequency (min/mean/max): <x> <y> <z> ; rel_range=0.012, input_soc_freq/detected=2.09
-```
-The `rel_range` number shows how narrow/wide the window of detected frequencies was.
-A narrow window indicates consistent trace data with well-calibrated cycle-to-clock conversion.
-The ratio of `input_soc_freq/detected` helps to determine whether the soc-freq setting on the cmdline was reasonably close to the reality of this trace.
-In best case, the relative range should be close to 0.0 and the input/detect-ratio is expected to be close to 1.0.
-
-Consequences when in use:
- * see [here](#understanding-and-troubleshooting-the-results) for various problems that can be caused or alleviated by this parameter
-
-
-### overlap
-
-A lot of things are asynchronously processed and the corresponding events are not possible to view as a proper call stack in either of the 2 viewers (chrome, perfetto). The tool provides 3 options via `-O nnn` argument to resolve situations where events overlap in that way:
- 1) increase the thread ID to separate `tid` (default, recommended)
- 2) drop conflicting events `drop` (intended for debugging and not recommended)
- 3) convert some events into asynchronous events `async` (deprecated, incomplete implementation of subsequent processing stages and thus not recommended to use)
-
-
 ### keep_prep
 
-By default, so-called *prep* events are removed from the view and represented as a counter (`ConcurrentPreps`) that shows how many of these events are active at a given time.  This option tells acelyzer to keep the events as visible events in their thread.
+By default, so-called *prep* events (flex traces only) are removed from the view and represented as a counter (`ConcurrentPreps`) that shows how many of these events are active at a given time.  This option tells acelyzer to keep the events as visible events in their thread.
 
 Consequences when in use:
  * adds a (potentially) large amount of events to become visible that are also often overlapping

--- a/src/aiu_trace_analyzer/pipeline/categorize.py
+++ b/src/aiu_trace_analyzer/pipeline/categorize.py
@@ -383,6 +383,8 @@ class EventCategorizerContext(TwoPhaseWithBarrierContext):
             during the initial pass through trace events. Tracks first_ts separately for
             each rank to enable proper per-rank timestamp normalization.
         """
+        assert "args" in event, "BUG: Classifier (first pass) detected X-event without 'args'" \
+            " which should have been added by ingestion or previous stages."
         rank = event["args"].get("rank", 0)
         if rank not in self.first_ts_per_rank:
             self.first_ts_per_rank[rank] = event["ts"]

--- a/src/aiu_trace_analyzer/pipeline/coll_group.py
+++ b/src/aiu_trace_analyzer/pipeline/coll_group.py
@@ -253,7 +253,7 @@ class CollectiveGroupingContext(EventPairDetectionContext):
         # filter the queue for Prep and non-Prep events:
         preps = filter(lambda e: _FLOW_STEP in e and e[_FLOW_STEP] == 0, queue)
         execs = list(filter(lambda e: _FLOW_STEP in e and e[_FLOW_STEP] == 1, queue))
-        regex = re.compile("(.*) [PE][rx][e][pc]$")  # everything except Prep/Exec at the end
+        regex = re.compile("(.*) [PE][rx]e[pc]$")  # everything except Prep/Exec at the end
 
         flow_pairs = []
         remove = []
@@ -385,8 +385,8 @@ class CollectiveGroupingContext(EventPairDetectionContext):
         for event in group_state.queue:
             self.update_rank_first_last_event(event, group_state)
 
-    def build_flows(self, groupID: int) -> list[TraceEvent]:
-        group_state = self.queues.pop(groupID, None)
+    def build_flows(self, group_id: int) -> list[TraceEvent]:
+        group_state = self.queues.pop(group_id, None)
         if not group_state:
             return []
 
@@ -546,8 +546,8 @@ class CollectiveGroupingContext(EventPairDetectionContext):
 
         # from where to where the arrow should go:
         src_event["ts"] = src["ts"]
-        # dst_event["ts"] = round(dst["ts"] + dst["dur"] - 0.0005, 3)
         dst_event["ts"] = dst["ts"] + dst["dur"] - 0.001
+        # alternative with rounding: dst_event["ts"] = round(dst["ts"] + dst["dur"] - 0.0005, 3)
 
         if src_event["ts"] > dst_event["ts"]:
             aiulog.log(aiulog.DEBUG,
@@ -814,10 +814,13 @@ def flow_prepare_event_data(event: TraceEvent, _: AbstractContext) -> list[Trace
         # preserve the type
         if _KEY_TYPE in event["args"]:
             flow_extraction_event[_KEY_TYPE] = _event_type_map[event["args"][_KEY_TYPE]]
+            '''
+            Additional timestamp refinement for SEND types:
             # if flow_extraction_event[_KEY_TYPE] == _TYPE_SEND:
             #     flow_extraction_event["ts"] = flow_extraction_event["args"]["ts_all"][3]
             #     flow_extraction_event["dur"] = flow_extraction_event["args"]["ts_all"][4] \
             #          - flow_extraction_event["args"]["ts_all"][3]
+            '''
         else:
             flow_extraction_event[_KEY_TYPE] = _TYPE_NONE
 
@@ -838,7 +841,7 @@ def flow_prepare_event_data(event: TraceEvent, _: AbstractContext) -> list[Trace
 def flow_data_cleanup(event: TraceEvent, _: AbstractContext) -> list[TraceEvent]:
     if event["ph"] == "F":
         return []
-    # event.pop(_FLOW_SYNC, "")
-    # event.pop(_FLOW_IO, "")
-    # event.pop(_FLOW_STEP, "")
+    event.pop(_FLOW_SYNC, "")
+    event.pop(_FLOW_IO, "")
+    event.pop(_FLOW_STEP, "")
     return [event]

--- a/src/aiu_trace_analyzer/pipeline/normalize.py
+++ b/src/aiu_trace_analyzer/pipeline/normalize.py
@@ -253,7 +253,7 @@ class NormalizationContext(AbstractHashQueueContext):
             job_drift = int(epoch_start
                             - (self.queues[qid]["0"][0] + elapsed_epochs * self.OVERFLOW_TIME_SPAN_US))
             actual_freq = (abs_cycle - self.queues[qid]["0"][2]) / (ts - self.queues[qid]["0"][1]) \
-                if ts != self.queues[qid]["0"][1] else None
+                if not math.isclose(ts, self.queues[qid]["0"][1], abs_tol=1e-9) else None
             self.queues[qid][job] = (epoch_start, ts, cycle)
             aiulog.log(aiulog.DEBUG, "OVC: Next job reference Epoch", qid, job, epoch_start, job_drift, actual_freq)
             mi, ma, cnt, mean, madr = self.frequency_minmax

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -35,6 +35,9 @@ _table_data_limit = 500
 # keep disabled until db-lookup feature is implemented
 _kernel_db_feature_implemented = False
 
+# kernel event name postfix
+_kernel_event_name_postfix = " Cmpt Exec"
+
 
 class RCUTableFingerprint():
     _separator = '_'
@@ -440,7 +443,7 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
                     current_table: dict[str, int],
                     fprint: RCUTableFingerprint) -> RCUTableFingerprint:
         category = self._handle_category(kernel_and_cat)
-        kernel = kernel_and_cat[0]+" Cmpt Exec"
+        kernel = kernel_and_cat[0] + _kernel_event_name_postfix
         fprint.add(kernel, cycles * self.cycle_to_clock_factor)
 
         if kernel not in current_table:
@@ -585,7 +588,7 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
             json_path = kernel_dir / "perf" / "ideal_cycles.json"
             if not json_path.exists():
                 continue
-            kernel_name = kernel_dir.name + " Cmpt Exec"
+            kernel_name = kernel_dir.name + _kernel_event_name_postfix
             with open(json_path) as f:
                 entries = json.load(f)
             for entry in entries:
@@ -844,8 +847,8 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
         if "[N]" in rname and "args" in event and "fn_idx" in event["args"]:
             rname = self._name_converter.sub(str(event["args"]["fn_idx"]), event["name"], count=1)
 
-        if not rname.endswith("Cmpt Exec"):
-            rname += " Cmpt Exec"
+        if not rname.endswith(_kernel_event_name_postfix):
+            rname += _kernel_event_name_postfix
 
         return rname
 
@@ -874,7 +877,10 @@ class MultiRCUUtilizationContext(TwoPhaseWithBarrierContext, PipelineContextTool
         rank = event["pid"] * self.rank_factor
 
         if self.rcuctx[rank].autopilot:
-            ideal = self.get_ideal_dur("Total Cmpt Exec", event["pid"], self.fingerprint_get(jobhash))
+            ideal = self.get_ideal_dur(
+                self._total_cycles_kernel_name + _kernel_event_name_postfix,
+                event["pid"],
+                self.fingerprint_get(jobhash))
             self.counters.update(event, ideal, jobhash, rank)
             counters = self.counters.get_completed()
             for counter in counters:

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -345,15 +345,19 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
             if os.path.isfile(compiler_info):
                 # Workload is running on current stack
                 subdir, fpat = '/'.join(compiler_info.split('/')[:-1]), compiler_info.split('/')[-1]
-                compiler_log_name = list(pathlib.Path(subdir).rglob(fpat))[0]
-                self.extract_tables(compiler_log=compiler_log_name)
+                matches = list(pathlib.Path(subdir).rglob(fpat))
+                if not matches:
+                    raise FileNotFoundError(f"No files matching pattern: {fpat}")
+                self.extract_tables(compiler_log=matches[0])
             elif os.path.isdir(compiler_info):
                 # Workload is running on the Torch Spyre stack
                 self.extract_tables_from_inductor_dir(compiler_info)
             else:
                 raise ValueError(f"{compiler_info} Unrecognized compiler info file type. Expecting file or directory.")
-        except Exception as e:
-            aiulog.log(aiulog.ERROR, "UTL: Unable to read open/parse compiler info file.", compiler_info, e)
+        except (FileNotFoundError, PermissionError, IndexError) as e:
+            aiulog.log(aiulog.ERROR, "UTL: Unable to open/parse log file.", compiler_info, e)
+        except ValueError as e:
+            aiulog.log(aiulog.ERROR, e)
 
         for _, t in self.kernel_cycles.items():
             self.autopilot_detail = AutopilotDetail(t)

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -460,6 +460,46 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
                        kernel, category, self.kernel_cat_map[0][kernel])
         return fprint
 
+    def _detect_autopilot_line(self, line: str) -> bool:
+        if self._autopilot_pattern.search(line):
+            if not self.autopilot:
+                aiulog.log(
+                    aiulog.WARN, "UTL: Detected autopilot=on. Event categorization, cycles table matching"
+                    " and other utilization-related data might be unreliable.")
+            self.autopilot = True
+            return True
+        return False
+
+    def _check_obsolete_items(self, line: str) -> bool:
+        if self._clock_scaling.search(line):
+            aiulog.log(aiulog.WARN,
+                       "UTL: Found obsolete 'Ideal Cycle Scaling' setting in logfile."
+                       " This setting is ignored. Use '--freq=<soc>:<core>'.")
+            return True
+        return False
+
+    def _handle_iteration_mode(
+            self,
+            iter_mode: re.Match,
+            parse_mode: RCUTableParseMode) -> RCUTableParseMode:
+        iteration_phase = iter_mode.group(1)
+        parse_mode = parse_mode.update(iteration_phase)
+        aiulog.log(aiulog.DEBUG, "DETECTED:", iteration_phase, "table to be next. Parsemode:", parse_mode)
+        return parse_mode
+
+    def _handle_start_table(
+            self,
+            parse_mode: RCUTableParseMode) -> tuple[
+                RCUTableParseMode,
+                dict[str, int],
+                RCUTableFingerprint]:
+        parse_mode |= RCUTableParseMode.ACTIVE_TABLE
+        current_table, fprint = self._start_init_table(parse_mode.get_phase())
+        aiulog.log(aiulog.DEBUG,
+                   "UTL: Start of Ideal Cycle Count section detected. Parse mode:",
+                   parse_mode, self.multi_table)
+        return parse_mode, current_table, fprint
+
     def _process_table_line(self,
                             line: str,
                             fprint: RCUTableFingerprint,
@@ -471,33 +511,19 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
                                 RCUTableFingerprint]:
 
         # detect autopilot on/off
-        if self._autopilot_pattern.search(line):
-            if not self.autopilot:
-                aiulog.log(
-                    aiulog.WARN, "UTL: Detected autopilot=on. Event categorization, cycles table matching"
-                    " and other utilization-related data might be unreliable.")
-            self.autopilot = True
+        if self._detect_autopilot_line(line):
             return True, parse_mode, current_table, fprint
 
-        if self._clock_scaling.search(line):
-            aiulog.log(aiulog.WARN,
-                       "UTL: Found obsolete 'Ideal Cycle Scaling' setting in logfile."
-                       " This setting is ignored. Use '--freq=<soc>:<core>'.")
+        if self._check_obsolete_items(line):
             return True, parse_mode, current_table, fprint
 
         _iter_mode = self._iteration_mode_pattern.search(line)
         if _iter_mode is not None:
-            iteration_phase = _iter_mode.group(1)
-            parse_mode = parse_mode.update(iteration_phase)
-            aiulog.log(aiulog.DEBUG, "DETECTED:", iteration_phase, "table to be next. Parsemode:", parse_mode)
+            parse_mode = self._handle_iteration_mode(_iter_mode, parse_mode)
             return True, parse_mode, current_table, fprint
 
         if self._start_pattern.search(line):
-            parse_mode |= RCUTableParseMode.ACTIVE_TABLE
-            current_table, fprint = self._start_init_table(parse_mode.get_phase())
-            aiulog.log(aiulog.DEBUG,
-                       "UTL: Start of Ideal Cycle Count section detected. Parse mode:",
-                       parse_mode, self.multi_table)
+            parse_mode, current_table, fprint = self._handle_start_table(parse_mode)
             return True, parse_mode, current_table, fprint
 
         # don't bother checking for the end_pattern if we're not even in parse mode

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -124,7 +124,10 @@ class RCUTableFingerprint():
                 f"0.0  <- ({other.totaltime} / {self.totaltime} = {other.totaltime / self.totaltime})")
             return 0.0
 
-        # TODO: Add check for self.totaltime != 0
+        # total-time similarity
+        if isclose(self.totaltime, 0.0, abs_tol=1e-9):
+            zero_match_factor = int(isclose(other.totaltime, 0.0, abs_tol=1e-9)) * 1.0
+            sim_val += self.sim_weights["total_time"] * zero_match_factor
         sim_val += self.sim_weights["total_time"] * (other.totaltime / self.totaltime)
         aiulog.log(
             aiulog.DEBUG, "   SIMVAL(totaltim):",

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -43,7 +43,7 @@ class RCUTableFingerprint():
             self,
             datalimit: int = -1,
             event_filter: str = r'',
-            table_mode: str = "UNKN"):
+            table_mode: str = "UNKN") -> None:
         self.datalimit = datalimit if datalimit > 0 else 1 << 31   # yes, it's not really unlimited...
         self.event_filter = re.compile(event_filter)
         self.table_mode = table_mode
@@ -57,7 +57,7 @@ class RCUTableFingerprint():
     def get(self) -> int:
         return self.hash
 
-    def get_table_mode(self) -> int:
+    def get_table_mode(self) -> str:
         return self.table_mode
 
     def add(self, data: str, time: float) -> None:
@@ -133,7 +133,7 @@ class RCUTableFingerprint():
 
 
 class RCUKernelCategoryMap():
-    def __init__(self):
+    def __init__(self) -> None:
         self.kernel_cat_map: dict[str, str] = {"other": "other"}
 
     def __getitem__(self, key: str) -> str:
@@ -525,7 +525,7 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
         fprint = self._add_kernel(kernel_and_cat, cycles, current_table, fprint)
         return True, parse_mode, current_table, fprint
 
-    def extract_tables(self, compiler_log: str):
+    def extract_tables(self, compiler_log: pathlib.Path):
 
         parse_mode = RCUTableParseMode(RCUTableParseMode.UNKNOWN)
         self.multi_table = -1  # track if there might be multiple tables in the log

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -357,7 +357,7 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
                 self.extract_tables_from_inductor_dir(compiler_info)
             else:
                 raise ValueError(f"{compiler_info} Unrecognized compiler info file type. Expecting file or directory.")
-        except (FileNotFoundError, PermissionError, IndexError) as e:
+        except (FileNotFoundError, PermissionError, IndexError, TypeError) as e:
             aiulog.log(aiulog.ERROR, "UTL: Unable to open/parse log file.", compiler_info, e)
         except ValueError as e:
             aiulog.log(aiulog.ERROR, e)


### PR DESCRIPTION
A few maintenance items before cutting the next release.

 * consistent kernel name suffix: use variable/constant instead of repeated string
 * break-up of rcu line parsing function: reduce function complexity
 * cover table similarity if total time is zero
 * restore cleanup code; updated comments
 * remove exact match float comparison
 * more specific exception handling when reading rcu util input files
 * check for args attribute before attempting to classify events
 * rcu_utilization maintenance
