### PR TITLE
pipeline: make pipeline_barrier context-aware, give each stage its own barrier

### DIFF
--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -498,10 +498,11 @@ class Acelyzer:
             filterstr=args.event_filter,
             event_limit=event_pipe.EventLimiter(args.event_limit))
         frequency_align_ctx = event_pipe.FlexJobOffsetContext(soc_frequency=args.freq[0])
+        normalize_barrier_ctx = event_pipe.BarrierContext()
         process.register_stage(callback=event_pipe.normalize_phase1, context=normalize_ctx)
         if args.flex_ts_fix:
             process.register_stage(callback=event_pipe.frequency_align_collect, context=frequency_align_ctx)
-        process.register_stage(callback=event_pipe.pipeline_barrier, context=event_pipe._main_barrier_context)
+        process.register_stage(callback=event_pipe.pipeline_barrier, context=normalize_barrier_ctx)
         if args.flex_ts_fix:
             process.register_stage(callback=event_pipe.frequency_align_apply, context=frequency_align_ctx)
         process.register_stage(callback=event_pipe.normalize_phase2, context=normalize_ctx)
@@ -572,9 +573,10 @@ class Acelyzer:
         overlap_ctx = event_pipe.OverlapDetectionContext(overlap_resolve=overlap_arg,
                                                          ts_shift_threshold=self.defaults["ts_shift_threshold"],
                                                          max_tid_streams=args.max_tid_streams)
+        overlap_barrier_ctx = event_pipe.BarrierContext()
         if overlap_arg == event_pipe.OverlapDetectionContext.OVERLAP_RESOLVE_TID:
             process.register_stage(callback=event_pipe.detect_partial_overlap_tids, context=overlap_ctx)
-            process.register_stage(callback=event_pipe.pipeline_barrier, context=event_pipe._main_barrier_context)
+            process.register_stage(callback=event_pipe.pipeline_barrier, context=overlap_barrier_ctx)
         process.register_stage(callback=event_pipe.detect_partial_overlap_events, context=overlap_ctx)
 
         # validate that the overlap has not messed up the event stream ordering
@@ -635,10 +637,11 @@ class Acelyzer:
         monotonic_ts_ctx_c = event_pipe.TSSequenceContext(ts3check=True)
         process.register_stage(callback=event_pipe.assert_ts_sequence, context=monotonic_ts_ctx_c)
 
+        comm_barrier_ctx = event_pipe.BarrierContext()
         if args.comm_summarize_seq:
             communication_event_ctx = event_pipe.CommunicationGroupContext()
             process.register_stage(callback=event_pipe.communication_event_collection, context=communication_event_ctx)
-        process.register_stage(callback=event_pipe.pipeline_barrier, context=event_pipe._main_barrier_context)
+        process.register_stage(callback=event_pipe.pipeline_barrier, context=comm_barrier_ctx)
 
         if args.comm_summarize_seq:
             process.register_stage(callback=event_pipe.communication_event_apply, context=communication_event_ctx)
@@ -659,9 +662,10 @@ class Acelyzer:
         categorizer_ctx = event_pipe.EventCategorizerContext(with_zero_align=(args.format == "timeline"))
 
         launch_flows_ctx = event_pipe.LaunchFLowContext()
+        categorize_barrier_ctx = event_pipe.BarrierContext()
         process.register_stage(callback=event_pipe.launch_flow_collect, context=launch_flows_ctx)
         process.register_stage(callback=event_pipe.event_categorizer, context=categorizer_ctx)
-        process.register_stage(callback=event_pipe.pipeline_barrier, context=event_pipe._main_barrier_context)
+        process.register_stage(callback=event_pipe.pipeline_barrier, context=categorize_barrier_ctx)
         process.register_stage(callback=event_pipe.event_categorizer_update, context=categorizer_ctx)
         process.register_stage(callback=event_pipe.launch_flow_create_missing, context=launch_flows_ctx)
 

--- a/src/aiu_trace_analyzer/pipeline/__init__.py
+++ b/src/aiu_trace_analyzer/pipeline/__init__.py
@@ -101,7 +101,7 @@ from aiu_trace_analyzer.pipeline.cmpt_collection import queueing_counter
 from aiu_trace_analyzer.pipeline.rcu_utilization import compute_utilization, compute_utilization_fingerprints
 from aiu_trace_analyzer.pipeline.tb_refinement import tb_refinement_intrusive, tb_refinement_lightweight
 from aiu_trace_analyzer.pipeline.iteration_detect import collect_iteration_stats
-from aiu_trace_analyzer.pipeline.barrier import pipeline_barrier, _main_barrier_context
+from aiu_trace_analyzer.pipeline.barrier import pipeline_barrier, _main_barrier_context, BarrierContext
 from aiu_trace_analyzer.pipeline.flex_job_offset import frequency_align_collect, frequency_align_apply
 from aiu_trace_analyzer.pipeline.flow_launch import launch_flow_collect, launch_flow_create_missing
 from aiu_trace_analyzer.pipeline.power_stats import analyze_power_statistics

--- a/src/aiu_trace_analyzer/pipeline/barrier.py
+++ b/src/aiu_trace_analyzer/pipeline/barrier.py
@@ -6,7 +6,7 @@ from aiu_trace_analyzer.types import TraceEvent, TraceWarning
 from aiu_trace_analyzer.pipeline import AbstractContext, AbstractHashQueueContext
 
 
-class _BarrierContext(AbstractContext):
+class BarrierContext(AbstractContext):
     def __init__(self) -> None:
         super().__init__()
         self.hold = []
@@ -20,12 +20,11 @@ class _BarrierContext(AbstractContext):
         return revents
 
 
-_main_barrier_context = _BarrierContext()
+_main_barrier_context = BarrierContext()
 
 
-def pipeline_barrier(event: TraceEvent, _: AbstractContext) -> list[TraceEvent]:
-    bctx = _main_barrier_context
-    bctx.collect(event)
+def pipeline_barrier(event: TraceEvent, ctx: AbstractContext) -> list[TraceEvent]:
+    ctx.collect(event)
     return []
 
 
@@ -44,8 +43,6 @@ class TwoPhaseWithBarrierContext(AbstractHashQueueContext):
         if self.phase == self._COLLECTION_PHASE:
             self.phase = self._APPLICATION_PHASE
         else:
-            # do nothing if this is the application phase
             pass
-        # the queues for these contexts don't contain events (events are held in barrier context),
-        # so nothing to drain here
+        # events are held in the barrier context, not here
         return []

--- a/tests/aiu_trace_analyzer/pipeline/test_barrier.py
+++ b/tests/aiu_trace_analyzer/pipeline/test_barrier.py
@@ -3,7 +3,7 @@
 import pytest
 
 from aiu_trace_analyzer.pipeline import pipeline_barrier
-from aiu_trace_analyzer.pipeline.barrier import _main_barrier_context
+from aiu_trace_analyzer.pipeline.barrier import BarrierContext
 
 
 list_test_cases = [
@@ -13,22 +13,40 @@ list_test_cases = [
 
 @pytest.mark.parametrize('generate_event_list, explen', list_test_cases, indirect=['generate_event_list'])
 def test_pipeline_barrier(generate_event_list, explen):
+    barrier_ctx = BarrierContext()
     assert len(generate_event_list) == explen
 
-    # insert all generated events
     for e in generate_event_list:
-        assert pipeline_barrier(e, None) == []
+        assert pipeline_barrier(e, barrier_ctx) == []
 
-    # make sure all events are held
-    assert len(_main_barrier_context.hold) == explen
+    assert len(barrier_ctx.hold) == explen
 
-    # retrieve the events list via drain
-    held_list = _main_barrier_context.drain()
+    held_list = barrier_ctx.drain()
 
-    # make sure the order did not change
     for a, b in zip(generate_event_list, held_list):
         assert a == b
 
-    # make sure another call of drain would come back empty
-    # this is important because there's supposedly only one global barrier context that's being reused
-    assert _main_barrier_context.hold == []
+    assert barrier_ctx.hold == []
+
+
+def test_independent_barrier_contexts_do_not_share_events():
+    ctx1 = BarrierContext()
+    ctx2 = BarrierContext()
+    e1 = {"ph": "X", "ts": 1, "pid": 0, "tid": 0, "name": "a"}
+    e2 = {"ph": "X", "ts": 2, "pid": 0, "tid": 0, "name": "b"}
+
+    pipeline_barrier(e1, ctx1)
+    pipeline_barrier(e2, ctx2)
+
+    assert ctx1.drain() == [e1]
+    assert ctx2.drain() == [e2]
+    assert ctx1.hold == []
+    assert ctx2.hold == []
+
+
+def test_barrier_drain_clears_hold():
+    ctx = BarrierContext()
+    e = {"ph": "X", "ts": 1, "pid": 0, "tid": 0, "name": "a"}
+    pipeline_barrier(e, ctx)
+    ctx.drain()
+    assert ctx.drain() == []


### PR DESCRIPTION
## What this does

First concrete step toward the pipeline restructuring tracked in #100.

`pipeline_barrier` ignored its context parameter and always wrote events to the module-level `_main_barrier_context` singleton. All four barrier registrations in `register_processing_functions` shared one queue. That made independent per-stage barriers impossible and made the context parameter misleading — every call site passed `event_pipe._main_barrier_context` but the function never used it.

## Root cause

```python
# before
def pipeline_barrier(event: TraceEvent, _: AbstractContext) -> list[TraceEvent]:
    bctx = _main_barrier_context   # always the global, ignoring the argument
    bctx.collect(event)
    return []
```

## Changes

**`src/aiu_trace_analyzer/pipeline/barrier.py`**
- `_BarrierContext` renamed to `BarrierContext` (public) so call sites can create instances without importing a private name.
- `pipeline_barrier` now uses `ctx.collect(event)` — the context it is passed — instead of the hardwired global.
- `_main_barrier_context` is kept as a `BarrierContext()` singleton for backwards compatibility; any call site that still passes it gets the same shared-barrier semantics as before.

**`src/aiu_trace_analyzer/pipeline/__init__.py`**
- `BarrierContext` exported so `acelyzer.py` and future `PipelineStage` code can create instances via the normal `event_pipe` namespace.

**`src/aiu_trace_analyzer/core/acelyzer.py`**
- Each of the four logical barrier groups in `register_processing_functions` now owns a named `BarrierContext` instance:

| Name | Logical stage |
|---|---|
| `normalize_barrier_ctx` | frequency_align / normalize phase |
| `overlap_barrier_ctx` | overlap_tid detection (conditional) |
| `comm_barrier_ctx` | comm_summarize / rcu_util |
| `categorize_barrier_ctx` | event categorizer |

No change to registration order or conditional logic.

**`tests/aiu_trace_analyzer/pipeline/test_barrier.py`**
- Updated existing test to pass a `BarrierContext` instance (previously passed `None`, which only worked because the function ignored its argument).
- `test_independent_barrier_contexts_do_not_share_events`: two barriers with separate contexts hold and drain their own events independently.
- `test_barrier_drain_clears_hold`: drain empties the hold list.

## Validation

```
PYTHONPATH=src python3 -m pytest
# 157 passed, 5 xfailed
```

## What this unblocks

With barriers context-aware and `BarrierContext` public, a `PipelineStage` class (next step in #100) can own its barrier instance and call `pipeline_barrier` correctly without any global state. The `_main_barrier_context` singleton is still available for the shared-barrier case but is no longer required.