### PR TITLE
keep zero-duration events and warn about non-zero hw time

### DIFF
--- a/src/aiu_trace_analyzer/ingest/ingestion.py
+++ b/src/aiu_trace_analyzer/ingest/ingestion.py
@@ -46,11 +46,17 @@ class AbstractTraceIngest:
             "zero_duration": TraceWarning(
                 name="zero_duration",
                 text=f"Ingestion: ..{str(source_uri)[-15:]} Detected 'CompleteEvent' type (ph=X) with zero duration. "
-                     "This should be an 'InstantEvent' type (ph=i). Events skipped: {d[count]}",
+                     "This should be an 'InstantEvent' type (ph=i). Events: {d[count]}",
                 data={"count": 0}),
             "negative_duration": TraceWarning(
                 name="negative_duration",
                 text="Ingestion: detected negative duration event(s). Events ignored:{d[count]}",
+                data={"count": 0}),
+            "zero_with_hw_time": TraceWarning(
+                name="zero_with_hw_time",
+                text=f"Ingestion: ..{str(source_uri)[-15:]} Detected "
+                     "{d[count]} events with zero wallclock but nonzero HW time. "
+                     "Indication of time calibration errors during trace capture.",
                 data={"count": 0})
         }
         self.verification_mode = verification_mode
@@ -204,6 +210,15 @@ class AbstractTraceIngest:
         else:
             return "args"
 
+    def _zero_with_hw_time(self, event: TraceEvent, the_args: str) -> TraceEvent:
+        # check if event with zero duration has non-zero HW cycle diff
+        if math.isclose(event.get("dur", -1.0), 0.0, abs_tol=1e-9) and the_args in event:
+            ts1 = event[the_args].get("TS1", 0)
+            ts5 = event[the_args].get("TS5", 0)
+            if ts1 != ts5:
+                self.warnings['zero_with_hw_time'].update()
+        return event
+
     # update event data with things like ts-offset or ts-scaling
     def updated_event(self, event: TraceEvent) -> TraceEvent:
         the_args = self._detect_args_type(event)
@@ -314,7 +329,7 @@ class JsonEventTraceIngest(AbstractTraceIngest):
         assert self._initialized is True, "ERROR: Data not initialized."
         return self
 
-    def get_next_event(self) -> TraceEvent:
+    def get_next_event(self) -> Optional[TraceEvent]:
         if self._index < self._len:
             item = self.data[self._index]
             self._index += 1
@@ -334,7 +349,7 @@ class JsonEventTraceIngest(AbstractTraceIngest):
 
         if math.isclose(event["dur"], 0.0, abs_tol=1e-9):
             self.issue_warning('zero_duration')
-            return None
+            return event
 
         return event
 
@@ -611,6 +626,8 @@ class MultifileIngest(AbstractTraceIngest):
                     self.disable_ingest(idx)
                     break
         # no extra 'updateEvent' here. That's already done in the specific ingesters
+        event = self._zero_with_hw_time(event, "attr")
+
         return event
 
     def update_event_front(self, event, idx):

--- a/src/aiu_trace_analyzer/ingest/ingestion.py
+++ b/src/aiu_trace_analyzer/ingest/ingestion.py
@@ -626,7 +626,7 @@ class MultifileIngest(AbstractTraceIngest):
                     self.disable_ingest(idx)
                     break
         # no extra 'updateEvent' here. That's already done in the specific ingesters
-        event = self._zero_with_hw_time(event, "attr")
+        event = self._zero_with_hw_time(event, self._detect_args_type(event))
 
         return event
 

--- a/tests/aiu_trace_analyzer/inout/test_ingestion.py
+++ b/tests/aiu_trace_analyzer/inout/test_ingestion.py
@@ -35,7 +35,7 @@ def test_json_input(json_input, capsys):
     for _ in json_ingest.__iter__():
         count += 1
 
-    assert count == 20
+    assert count == 22
     capsys.readouterr()
     del json_ingest
 

--- a/tests/aiu_trace_analyzer/inout/test_ingestion.py
+++ b/tests/aiu_trace_analyzer/inout/test_ingestion.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from aiu_trace_analyzer.ingest.ingestion import JsonFileEventTraceIngest
+from aiu_trace_analyzer.ingest.ingestion import JsonFileEventTraceIngest, MultifileIngest
 
 
 @pytest.fixture
@@ -35,7 +35,7 @@ def test_json_input(json_input, capsys):
     for _ in json_ingest.__iter__():
         count += 1
 
-    assert count == 22
+    assert count == 23
     capsys.readouterr()
     del json_ingest
 
@@ -119,25 +119,27 @@ def test_json_iterator(generate_event_list, exp_len, json_input):
 
 
 warnings_to_test = [
-    ("zero_duration", "with zero duration", 2),
-    ("negative_duration", "negative duration event", 1)
+    ("zero_duration", "with zero duration", 3, JsonFileEventTraceIngest),
+    ("negative_duration", "negative duration event", 1, JsonFileEventTraceIngest),
+    ("zero_with_hw_time", "zero wallclock but nonzero HW time", 1, MultifileIngest)
 ]
 
 
-@pytest.mark.parametrize("warning_class, expected_text, count", warnings_to_test)
-def test_summary_warnings(warning_class, expected_text, count, json_input, capsys):
+@pytest.mark.parametrize("warning_class, expected_text, count, ingester_class", warnings_to_test)
+def test_summary_warnings(warning_class, expected_text, count, ingester_class, json_input, capsys):
     # create obj for this test because we're testing __del__
-    json_ingest = JsonFileEventTraceIngest(json_input)
+    # Create obj directly (not using fixture) to ensure proper deletion
+    ingest = ingester_class(json_input)
 
     # iterate through events to create issued warnings
-    for _ in json_ingest:
+    for _ in ingest:
         pass
 
-    assert json_ingest.warnings[warning_class].has_warning() is True
-    assert json_ingest.warnings[warning_class].args_list['count'] == count
+    assert ingest.warnings[warning_class].has_warning() is True
+    assert ingest.warnings[warning_class].args_list['count'] == count
 
-    if json_ingest.warnings[warning_class].has_warning():
-        del json_ingest
+    if ingest.warnings[warning_class].has_warning():
+        del ingest
         output = capsys.readouterr()
         assert "WARNING" in output.out
         assert expected_text in output.out

--- a/tests/test_data/basic_event_test_cases.json
+++ b/tests/test_data/basic_event_test_cases.json
@@ -51,6 +51,9 @@
 
     {"name": "CaseZeroDurA",  "cat": "CatA",   "ph": "X",    "pid": 0,    "tid": 0,  "ts": 170, "dur": 0.0, "comment": "Zero-duration event type X. Should create a warning."},
     {"name": "CaseZeroDurB",   "cat": "CatA",     "ph": "B",    "pid": 0,    "tid": 5,  "ts": 180, "comment": "Zero-duration event type BE. Should create a warning."},
-    {"name": "CaseZeroDurB",   "cat": "CatA",     "ph": "E",    "pid": 0,    "tid": 5,  "ts": 180}
+    {"name": "CaseZeroDurB",   "cat": "CatA",     "ph": "E",    "pid": 0,    "tid": 5,  "ts": 180},
+    {"name": "CaseZeroDurC",  "cat": "CatA",   "ph": "X",    "pid": 0,    "tid": 0,  "ts": 190, "dur": 0.0,
+        "args": {"TS1": "100", "TS2": "200", "TS3": "300", "TS4": "400", "TS5": "500"},
+        "comment": "Zero-duration event with non-zero HW-time. Should create a warning."}
 
 ]


### PR DESCRIPTION
Up to now, any X-event with zero duration would have been dropped from processing and a warning issued about such thing should be an 'instant event' (ph='i').

This PR changes this policy to:
 * keep the zero events
 * still warn about it (should really be 'i'-events
 * checks for available HW timer info and especially warns if they indicate non-zero hw time

This helps identifying problems with time calibration and timing issues in the sw that captures the trace.