### PR TITLE
Suppress teardown output for profile-disabled stages

### DIFF
--- a/src/aiu_trace_analyzer/pipeline/coll_group.py
+++ b/src/aiu_trace_analyzer/pipeline/coll_group.py
@@ -72,6 +72,8 @@ class CollectiveGroupingContext(EventPairDetectionContext):
         self.coll_algo = None
 
     def __del__(self) -> None:
+        if not self.was_activated():
+            return
         if self.problem_count:
             aiulog.log(aiulog.WARN, "FLOW: Number of potential problems detected =", self.problem_count)
             print('src\tdst\trecv_before_send')

--- a/src/aiu_trace_analyzer/pipeline/coll_group.py
+++ b/src/aiu_trace_analyzer/pipeline/coll_group.py
@@ -72,7 +72,7 @@ class CollectiveGroupingContext(EventPairDetectionContext):
         self.coll_algo = None
 
     def __del__(self) -> None:
-        if not self.was_activated():
+        if not self.is_enabled():
             return
         if self.problem_count:
             aiulog.log(aiulog.WARN, "FLOW: Number of potential problems detected =", self.problem_count)

--- a/src/aiu_trace_analyzer/pipeline/context.py
+++ b/src/aiu_trace_analyzer/pipeline/context.py
@@ -40,6 +40,9 @@ class AbstractContext:
             self._disable_warnings()
         return self.is_enabled
 
+    def was_activated(self) -> bool:
+        return self.is_enabled
+
     def _disable_warnings(self) -> None:
         for _, w in self.warnings.items():
             w.occurred = False

--- a/src/aiu_trace_analyzer/pipeline/context.py
+++ b/src/aiu_trace_analyzer/pipeline/context.py
@@ -23,25 +23,25 @@ class AbstractContext:
     '''
     def __init__(self, warnings: list[TraceWarning] = None) -> None:
         self.warnings: dict[str, TraceWarning] = {}
-        self.is_enabled = False
+        self.enabled = False
 
         if warnings is not None:
             for w in warnings:
                 self.add_warning(w)
 
     def enable(self) -> bool:
-        self.is_enabled = True
-        return self.is_enabled
+        self.enabled = True
+        return self.enabled
 
     def disable(self) -> bool:
         # use OR to make sure any previous activation cannot be overwritten
-        self.is_enabled |= False
-        if not self.is_enabled:
+        self.enabled |= False
+        if not self.enabled:
             self._disable_warnings()
-        return self.is_enabled
+        return self.enabled
 
-    def was_activated(self) -> bool:
-        return self.is_enabled
+    def is_enabled(self) -> bool:
+        return self.enabled
 
     def _disable_warnings(self) -> None:
         for _, w in self.warnings.items():

--- a/src/aiu_trace_analyzer/pipeline/dma.py
+++ b/src/aiu_trace_analyzer/pipeline/dma.py
@@ -32,6 +32,8 @@ class DataTransferExtractionContext(EventPairDetectionContext):
         self.ecount_out = 0
 
     def __del__(self):
+        if not self.was_activated():
+            return
         aiulog.log(aiulog.INFO, "DTC event stats o/i:", self.ecount_out, '/', self.ecount_in)
 
     # dma (bytes transferred) is per process, so we drop the tid information

--- a/src/aiu_trace_analyzer/pipeline/dma.py
+++ b/src/aiu_trace_analyzer/pipeline/dma.py
@@ -32,7 +32,7 @@ class DataTransferExtractionContext(EventPairDetectionContext):
         self.ecount_out = 0
 
     def __del__(self):
-        if not self.was_activated():
+        if not self.is_enabled():
             return
         aiulog.log(aiulog.INFO, "DTC event stats o/i:", self.ecount_out, '/', self.ecount_in)
 

--- a/src/aiu_trace_analyzer/pipeline/inverse_ts.py
+++ b/src/aiu_trace_analyzer/pipeline/inverse_ts.py
@@ -30,6 +30,8 @@ class InversedTSDetectionContext(AbstractContext):
         self.bad_count = 0
 
     def __del__(self) -> None:
+        if not self.was_activated():
+            return
         if self.bad_count > 0:
             aiulog.log(aiulog.WARN, "TS-Inversed events dropped:", self.bad_count)
 

--- a/src/aiu_trace_analyzer/pipeline/inverse_ts.py
+++ b/src/aiu_trace_analyzer/pipeline/inverse_ts.py
@@ -30,7 +30,7 @@ class InversedTSDetectionContext(AbstractContext):
         self.bad_count = 0
 
     def __del__(self) -> None:
-        if not self.was_activated():
+        if not self.is_enabled():
             return
         if self.bad_count > 0:
             aiulog.log(aiulog.WARN, "TS-Inversed events dropped:", self.bad_count)

--- a/src/aiu_trace_analyzer/pipeline/normalize.py
+++ b/src/aiu_trace_analyzer/pipeline/normalize.py
@@ -131,6 +131,9 @@ class NormalizationContext(AbstractHashQueueContext):
         self.event_limit = event_limit
 
     def __del__(self) -> None:
+        if not self.was_activated():
+            return
+
         def _print_freq_minmax(key: str):
             freq_min = 1e99
             freq_max = freq_mean = 0.0

--- a/src/aiu_trace_analyzer/pipeline/normalize.py
+++ b/src/aiu_trace_analyzer/pipeline/normalize.py
@@ -138,7 +138,7 @@ class NormalizationContext(AbstractHashQueueContext):
         self.event_limit = event_limit
 
     def __del__(self) -> None:
-        if not self.was_activated():
+        if not self.is_enabled():
             return
 
         def _print_freq_minmax(key: str):

--- a/src/aiu_trace_analyzer/pipeline/overlap.py
+++ b/src/aiu_trace_analyzer/pipeline/overlap.py
@@ -54,6 +54,8 @@ class OverlapDetectionContext(TwoPhaseWithBarrierContext):
         self.max_tid_streams = max_tid_streams
 
     def __del__(self) -> None:
+        if not self.was_activated():
+            return
         level = aiulog.WARN if self.resolved else aiulog.INFO
         aiulog.log(level, "Partial-overlap slices resolved:", self.resolved)
 

--- a/src/aiu_trace_analyzer/pipeline/overlap.py
+++ b/src/aiu_trace_analyzer/pipeline/overlap.py
@@ -54,7 +54,7 @@ class OverlapDetectionContext(TwoPhaseWithBarrierContext):
         self.max_tid_streams = max_tid_streams
 
     def __del__(self) -> None:
-        if not self.was_activated():
+        if not self.is_enabled():
             return
         level = aiulog.WARN if self.resolved else aiulog.INFO
         aiulog.log(level, "Partial-overlap slices resolved:", self.resolved)

--- a/src/aiu_trace_analyzer/pipeline/power.py
+++ b/src/aiu_trace_analyzer/pipeline/power.py
@@ -34,6 +34,8 @@ class PowerExtractionContext(AbstractHashQueueContext):
         self.bad_events = 0
 
     def __del__(self):
+        if not self.was_activated():
+            return
         if self.bad_events:
             aiulog.log(aiulog.WARN,
                        f"PEC encountered {self.bad_events} bad power events set to 0.0W."

--- a/src/aiu_trace_analyzer/pipeline/power.py
+++ b/src/aiu_trace_analyzer/pipeline/power.py
@@ -36,7 +36,7 @@ class PowerExtractionContext(AbstractHashQueueContext):
         self.bad_events = 0
 
     def __del__(self):
-        if not self.was_activated():
+        if not self.is_enabled():
             return
         if self.bad_events:
             aiulog.log(aiulog.WARN,

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -241,14 +241,16 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
             self.table_hash = self.autopilot_detail.table_hash()
 
     def __del__(self) -> None:
-        if self.is_enabled:
-            if self.multi_table > 0:  # used as index, so 'n-1'
-                aiulog.log(aiulog.WARN, f"UTL: {len(self.fingerprints)}/{self.multi_table+1} unique",
-                           "tables with ideal cycles have been detected."
-                           " Utilization results should be inspected carefully!!!!")
-            if self.unscaled:
-                aiulog.log(aiulog.WARN, "UTL: No ideal/real frequency unscaled (factor 1.0). "
-                           "Utilization might be based on undefined data.")
+        if not self.was_activated():
+            return
+
+        if self.multi_table > 0:  # used as index, so 'n-1'
+            aiulog.log(aiulog.WARN, f"UTL: {len(self.fingerprints)}/{self.multi_table+1} unique",
+                       "tables with ideal cycles have been detected."
+                       " Utilization results should be inspected carefully!!!!")
+        if self.unscaled:
+            aiulog.log(aiulog.WARN, "UTL: No ideal/real frequency unscaled (factor 1.0). "
+                       "Utilization might be based on undefined data.")
 
         # dealing with the kernel_db only makes sense if we detected any table at all
         if _kernel_db_feature_implemented and len(self.kernel_cycles):

--- a/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
+++ b/src/aiu_trace_analyzer/pipeline/rcu_utilization.py
@@ -370,7 +370,7 @@ class RCUUtilizationContext(AbstractContext, PipelineContextTool):
             self.table_hash = self.autopilot_detail.table_hash()
 
     def __del__(self) -> None:
-        if not self.was_activated():
+        if not self.is_enabled():
             return
 
         if self.multi_table > 0:  # used as index, so 'n-1'

--- a/src/aiu_trace_analyzer/pipeline/stats.py
+++ b/src/aiu_trace_analyzer/pipeline/stats.py
@@ -29,6 +29,8 @@ class StatsExtractionContext(EventPairDetectionContext, PipelineContextTool):
         self.max_ts_map = {}
 
     def __del__(self) -> None:
+        if not self.was_activated():
+            return
         for pid, data in self.total_util.items():
             mean_pt_util, tot_matmul, tot_other = data
             total = tot_matmul + tot_other

--- a/src/aiu_trace_analyzer/pipeline/stats.py
+++ b/src/aiu_trace_analyzer/pipeline/stats.py
@@ -29,7 +29,7 @@ class StatsExtractionContext(EventPairDetectionContext, PipelineContextTool):
         self.max_ts_map = {}
 
     def __del__(self) -> None:
-        if not self.was_activated():
+        if not self.is_enabled():
             return
         for pid, data in self.total_util.items():
             mean_pt_util, tot_matmul, tot_other = data

--- a/tests/aiu_trace_analyzer/pipeline/test_context.py
+++ b/tests/aiu_trace_analyzer/pipeline/test_context.py
@@ -136,3 +136,16 @@ def test_issue_warning(abstract_context):
 
 def test_drain(abstract_context):
     assert abstract_context.drain() == []
+
+
+def test_was_activated(abstract_context):
+    assert abstract_context.was_activated() is False
+
+    abstract_context.disable()
+    assert abstract_context.was_activated() is False
+
+    abstract_context.enable()
+    assert abstract_context.was_activated() is True
+
+    abstract_context.disable()
+    assert abstract_context.was_activated() is True

--- a/tests/aiu_trace_analyzer/pipeline/test_context.py
+++ b/tests/aiu_trace_analyzer/pipeline/test_context.py
@@ -138,14 +138,14 @@ def test_drain(abstract_context):
     assert abstract_context.drain() == []
 
 
-def test_was_activated(abstract_context):
-    assert abstract_context.was_activated() is False
+def test_is_enabled(abstract_context):
+    assert abstract_context.is_enabled() is False
 
     abstract_context.disable()
-    assert abstract_context.was_activated() is False
+    assert abstract_context.is_enabled() is False
 
     abstract_context.enable()
-    assert abstract_context.was_activated() is True
+    assert abstract_context.is_enabled() is True
 
     abstract_context.disable()
-    assert abstract_context.was_activated() is True
+    assert abstract_context.is_enabled() is True

--- a/tests/aiu_trace_analyzer/pipeline/test_deactivated_stage_output.py
+++ b/tests/aiu_trace_analyzer/pipeline/test_deactivated_stage_output.py
@@ -1,0 +1,85 @@
+# Copyright 2024-2026 IBM Corporation
+
+import aiu_trace_analyzer.logger as aiulog
+
+from aiu_trace_analyzer.pipeline.coll_group import CollectiveGroupingContext
+from aiu_trace_analyzer.pipeline.dma import DataTransferExtractionContext
+from aiu_trace_analyzer.pipeline.inverse_ts import InversedTSDetectionContext
+from aiu_trace_analyzer.pipeline.overlap import OverlapDetectionContext
+from aiu_trace_analyzer.pipeline.power import PowerExtractionContext
+from aiu_trace_analyzer.pipeline.rcu_utilization import RCUUtilizationContext
+from aiu_trace_analyzer.pipeline.stats import StatsExtractionContext
+
+
+def test_deactivated_stage_contexts_do_not_emit_output(monkeypatch, capsys):
+    log_calls = []
+    monkeypatch.setattr(aiulog, "log", lambda *args: log_calls.append(args))
+
+    contexts = []
+
+    dma_context = DataTransferExtractionContext()
+    dma_context.ecount_out = 3
+    dma_context.ecount_in = 4
+    dma_context.disable()
+    contexts.append(dma_context)
+
+    inverse_context = InversedTSDetectionContext()
+    inverse_context.bad_count = 2
+    inverse_context.disable()
+    contexts.append(inverse_context)
+
+    overlap_context = OverlapDetectionContext()
+    overlap_context.resolved = 5
+    overlap_context.disable()
+    contexts.append(overlap_context)
+
+    power_context = PowerExtractionContext()
+    power_context.bad_events = 1
+    power_context.ecount_out = 7
+    power_context.ecount_in = 9
+    power_context.disable()
+    contexts.append(power_context)
+
+    stats_context = StatsExtractionContext("unused")
+    stats_context.total_util[11] = (0.9, 10.0, 1.0)
+    stats_context.disable()
+    contexts.append(stats_context)
+
+    coll_context = CollectiveGroupingContext()
+    coll_context.problem_count = 1
+    coll_context.flow_div = {0: (1, 2, 3)}
+    coll_context.stale_drop = 2
+    coll_context.disable()
+    contexts.append(coll_context)
+
+    for context in contexts:
+        type(context).__del__(context)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert log_calls == []
+
+
+def test_deactivated_rcu_context_does_not_write_output(tmp_path):
+    compiler_log = tmp_path / "compiler.log"
+    compiler_log.write_text("")
+
+    csv_path = tmp_path / "utilization.csv"
+    db_path = tmp_path / "kernel.db"
+    txt_path = tmp_path / "utilization_categories.txt"
+
+    context = RCUUtilizationContext(
+        compiler_log=str(compiler_log),
+        csv_fname=str(csv_path),
+        soc_freq=1000.0,
+        core_freq=1000.0,
+        kernel_db_url=str(db_path),
+    )
+    context.categories = {1: {"Total": (1.0, 1.0, 1)}}
+    context.disable()
+
+    type(context).__del__(context)
+
+    assert csv_path.exists() is False
+    assert db_path.exists() is False
+    assert txt_path.exists() is False

--- a/tests/aiu_trace_analyzer/pipeline/test_deactivated_stage_output.py
+++ b/tests/aiu_trace_analyzer/pipeline/test_deactivated_stage_output.py
@@ -69,7 +69,7 @@ def test_deactivated_rcu_context_does_not_write_output(tmp_path):
     txt_path = tmp_path / "utilization_categories.txt"
 
     context = RCUUtilizationContext(
-        compiler_log=str(compiler_log),
+        compiler_info=str(compiler_log),
         csv_fname=str(csv_path),
         soc_freq=1000.0,
         core_freq=1000.0,


### PR DESCRIPTION
## Summary
- add a shared was_activated() helper on pipeline contexts to reflect whether a stage was ever enabled
- suppress destructor-time logging and side effects for stage contexts that were constructed but never activated because the stage profile disabled them
- add focused regression coverage for disabled contexts, including the RCU utilization file-writing path

## Testing
- python3 -m pytest tests/aiu_trace_analyzer/pipeline/test_context.py tests/aiu_trace_analyzer/pipeline/test_deactivated_stage_output.py -q
- python3 -m pytest tests/aiu_trace_analyzer/core/test_stage_profile.py -q
- python3 -m py_compile src/aiu_trace_analyzer/pipeline/context.py src/aiu_trace_analyzer/pipeline/coll_group.py src/aiu_trace_analyzer/pipeline/dma.py src/aiu_trace_analyzer/pipeline/inverse_ts.py src/aiu_trace_analyzer/pipeline/normalize.py src/aiu_trace_analyzer/pipeline/overlap.py src/aiu_trace_analyzer/pipeline/power.py src/aiu_trace_analyzer/pipeline/rcu_utilization.py src/aiu_trace_analyzer/pipeline/stats.py tests/aiu_trace_analyzer/pipeline/test_context.py tests/aiu_trace_analyzer/pipeline/test_deactivated_stage_output.py
- git diff --check

Closes #9