### PR TITLE
fix nested quotes

### DIFF
--- a/src/aiu_trace_analyzer/ingest/ingestion.py
+++ b/src/aiu_trace_analyzer/ingest/ingestion.py
@@ -152,7 +152,7 @@ class AbstractTraceIngest:
         if event["name"].endswith("sort_index"):
             event["args"]["sort_index"] = self.rank_pid * 123000 + is_no_cpu
         elif event["name"].endswith("_labels") and event["args"]["labels"][-1] in "0123456789":
-            event["args"]["labels"] = f"{event["args"]["labels"][:-1]}{self.rank_pid}"
+            event["args"]["labels"] = f"{event['args']['labels'][:-1]}{self.rank_pid}"
 
         return (event, finished)
 

--- a/src/aiu_trace_analyzer/pipeline/overlap.py
+++ b/src/aiu_trace_analyzer/pipeline/overlap.py
@@ -73,8 +73,8 @@ class OverlapDetectionContext(TwoPhaseWithBarrierContext):
 
         # make sure ts is monotonic increasing
         assert current_ts <= event["ts"], (
-            f"Events out-of-order[{event["tid"]}]: {current_ts},"
-            f" {event["ts"]}, {self.queues[queue_id]}")
+            f"Events out-of-order[{event['tid']}]: {current_ts},"
+            f" {event['ts']}, {self.queues[queue_id]}")
 
         event_ts = event["ts"]
         event_end = round(event["ts"] + event["dur"], 4)

--- a/src/aiu_trace_analyzer/pipeline/tools.py
+++ b/src/aiu_trace_analyzer/pipeline/tools.py
@@ -89,9 +89,9 @@ class PipelineContextTool:
                     return False
             assert isinstance(attribute, dict) is False, \
                 f"Attribute '{attribute}' is not a leaf node in '{category}'" \
-                f"classifier of {dialect.get("NAME")} dialect."
+                f"classifier of {dialect.get('NAME')} dialect."
             compare_str = ';'.join(deconstruct[1:])  # recombined remaining parts of the string
-            assert len(compare_str) > 0, f"Incorrect format '{category}' classifier of {dialect.get("NAME")} dialect."
+            assert len(compare_str) > 0, f"Incorrect format '{category}' classifier of {dialect.get('NAME')} dialect."
             classifier_re = re.compile(compare_str)
             return (classifier_re.search(str(attribute)) is not None)
 


### PR DESCRIPTION
some of the output strings were still using nested quotes of the same type which is a) bad style and b) fails on older versions of Python.

This PR is fixing those.