### PR TITLE
use Optional for back-compatibility with Python 3.9

### DIFF
--- a/src/aiu_trace_analyzer/core/stage_profile.py
+++ b/src/aiu_trace_analyzer/core/stage_profile.py
@@ -5,6 +5,7 @@ import json
 import os
 from pathlib import Path
 from copy import deepcopy
+from typing import Optional
 
 import aiu_trace_analyzer.logger as aiulog
 
@@ -97,7 +98,7 @@ class StageProfile:
         return ordered, recurring
 
     @staticmethod
-    def _parse_stage_key(stage_key: str) -> tuple[str, int | None]:
+    def _parse_stage_key(stage_key: str) -> tuple[str, Optional[int]]:
         if "#" not in stage_key:
             return stage_key, None
         stage_name, stage_index = stage_key.rsplit("#", 1)

--- a/src/aiu_trace_analyzer/pipeline/categorize.py
+++ b/src/aiu_trace_analyzer/pipeline/categorize.py
@@ -1,6 +1,7 @@
 # Copyright 2024-2025 IBM Corporation
 
 from enum import Enum, auto
+from typing import Optional
 
 import aiu_trace_analyzer.logger as aiulog
 from aiu_trace_analyzer.types import TraceEvent, TraceWarning
@@ -111,7 +112,7 @@ class EventCategorizerContext(TwoPhaseWithBarrierContext):
         """
         return "CollGroup" in event["args"]
 
-    def classify_flex(self, event: TraceEvent) -> (EventClass | None):   # noqa: C901
+    def classify_flex(self, event: TraceEvent) -> Optional[EventClass]:   # noqa: C901
         """Classify trace events using FLEX dialect-based classification.
 
         This method is currently kept for verification of the dialect-based classifier.

--- a/src/aiu_trace_analyzer/pipeline/tools.py
+++ b/src/aiu_trace_analyzer/pipeline/tools.py
@@ -31,7 +31,7 @@ class PipelineContextTool:
         return '.'.join(fcomponents)
 
     @staticmethod
-    def get_dialect_of_event(event: TraceEvent) -> InputDialect | None:
+    def get_dialect_of_event(event: TraceEvent) -> Optional[InputDialect]:
         if "args" not in event:
             return None
         if "jobhash" not in event["args"]:


### PR DESCRIPTION
Some poor souls on this planet are stuck with end-of-lifetime version of Python (looking at you RHEL users :wink: )

This PR is changing code features that require newer versions of Python to source that's compatible with 3.9.

(That said: the requirement for 3.10 in pyproject.toml remains because 3.9 is EOL for the rest of the planet.
If you can't escape the 3.9 on your system, you'll have to modify the pyproject.toml file before installation or use from source directly by setting pythonpath)