### PR TITLE
verification stage correlating kernels and parent cpu-events

### DIFF
--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -750,6 +750,10 @@ class Acelyzer:
                                         args,
                                         exporter: output.AbstractTraceExporter):
         verification_ctx = event_pipe.VerificationContext()
+        kernel_parent_ctx = event_pipe.KernelParentVerificationContext()
 
         process.register_stage(callback=event_pipe.verify, context=verification_ctx)
+        process.register_stage(callback=event_pipe.kernel_parent_collect, context=kernel_parent_ctx)
+        process.register_stage(callback=event_pipe.pipeline_barrier, context=event_pipe._main_barrier_context)
+        process.register_stage(callback=event_pipe.kernel_parent_verify, context=kernel_parent_ctx)
         process.register_stage(callback=event_pipe.verify_cleanup)

--- a/src/aiu_trace_analyzer/core/acelyzer.py
+++ b/src/aiu_trace_analyzer/core/acelyzer.py
@@ -164,7 +164,7 @@ class Acelyzer:
             sys.exit(1)
 
         # create event processor
-        profile = StageProfile.from_json(self.args.profile)
+        profile = StageProfile.from_json(self.args.profile, self.args.verification_mode)
         intermediate_file = self.args.output if self.args.intermediate else None
         process = processor.EventProcessor(profile=profile,
                                            intermediate=intermediate_file)

--- a/src/aiu_trace_analyzer/core/stage_profile.py
+++ b/src/aiu_trace_analyzer/core/stage_profile.py
@@ -11,18 +11,23 @@ import aiu_trace_analyzer.logger as aiulog
 
 class StageProfile:
     _everything_profile = os.path.join(os.path.dirname(__file__), "../profiles/everything.json")
+    _verification_profile = os.path.join(os.path.dirname(__file__), "../profiles/verification.json")
 
     def __init__(self, profile_data: dict, all_stages: dict):
         self.profile = self._ingest_profile_data(profile_data, all_stages)
 
     @classmethod
-    def from_json(cls, file: Path):
+    def from_json(cls, file: Path, verification_mode: bool = False):
+        everything = cls._everything_profile
+        if verification_mode:
+            everything = cls._verification_profile
+
         if not os.path.isfile(file):
             # try find profile file in default install location
-            file = os.path.join(os.path.dirname(__file__), "../profiles/", file)
+            file = Path(os.path.join(os.path.dirname(__file__), "../profiles/", file))
         with open(file, 'r') as config_fd:
             profile_data = json.load(config_fd)
-        with open(cls._everything_profile, 'r') as all_fd:
+        with open(everything, 'r') as all_fd:
             all_stages = json.load(all_fd)
 
         # if a profile is empty, then assume all stages to be enabled

--- a/src/aiu_trace_analyzer/pipeline/__init__.py
+++ b/src/aiu_trace_analyzer/pipeline/__init__.py
@@ -113,3 +113,8 @@ from aiu_trace_analyzer.pipeline.categorize import event_categorizer, event_cate
 
 from aiu_trace_analyzer.verification.verify import verify, verify_cleanup
 from aiu_trace_analyzer.verification.verify import VerificationContext
+from aiu_trace_analyzer.verification.kernel_parent_verify import (
+    KernelParentVerificationContext,
+    kernel_parent_collect,
+    kernel_parent_verify
+)

--- a/src/aiu_trace_analyzer/profiles/everything.json
+++ b/src/aiu_trace_analyzer/profiles/everything.json
@@ -56,8 +56,6 @@
         {"tb_refinement_lightweight": true},
         {"cycle_count_conversion_cleanup": true},
         {"calculate_stats_v2": true},
-        {"sort_events": true},
-        {"verify": true},
-        {"verify_cleanup": true}
+        {"sort_events": true}
     ]
 }

--- a/src/aiu_trace_analyzer/profiles/verification.json
+++ b/src/aiu_trace_analyzer/profiles/verification.json
@@ -1,6 +1,8 @@
 {
     "stages": [
-        {"verify": true},
+        {"kernel_parent_collect": true},
+        {"pipeline_barrier": true},
+        {"kernel_parent_verify": true},
         {"verify_cleanup": true}
     ]
 }

--- a/src/aiu_trace_analyzer/verification/kernel_parent_verify.py
+++ b/src/aiu_trace_analyzer/verification/kernel_parent_verify.py
@@ -1,0 +1,329 @@
+# Copyright 2024-2026 IBM Corporation
+
+"""
+Kernel-Parent Timestamp Verification Module
+
+This module implements verification logic to ensure that kernel events are properly
+contained within their parent 'ScheduleCompute' event timeframes. This verification
+is critical for validating trace data integrity and detecting timing anomalies.
+
+The verification uses a two-phase processing approach:
+1. Collection Phase: Gather parent (ScheduleCompute) timing information and track kernel counts
+2. Verification Phase: Check each kernel event against its parent's timeframe
+
+Key Features:
+- Verifies kernel events fit within parent ScheduleCompute event bounds
+- Detects orphan kernels (kernels without parent events)
+- Detects orphan parents (parent events without any kernels)
+- Reports violations as errors that fail verification mode
+- Works with both Torch and Flex trace dialects
+
+Data Structure:
+    For each correlation ID, tracks:
+    - parent_start: Minimum start timestamp across all parent events (inf if not seen)
+    - parent_end: Maximum end timestamp across all parent events (-inf if not seen)
+    - kernel_count: Number of kernel events seen for this correlation ID
+
+Usage:
+    This module is designed to be integrated into the verification pipeline profile.
+    It requires a pipeline barrier between collection and verification phases.
+
+    Example integration:
+        ctx = KernelParentVerificationContext()
+        processor.register_stage(callback=kernel_parent_collect, context=ctx)
+        processor.register_stage(callback=pipeline_barrier, context=barrier_ctx)
+        processor.register_stage(callback=kernel_parent_verify, context=ctx)
+
+Warnings Tracked:
+    - kernel_outside_parent: Kernels detected outside parent timeframe (ERROR)
+    - orphan_kernels: Kernels without a parent ScheduleCompute event
+    - orphan_parents: Parent ScheduleCompute events without any kernels
+"""
+
+import math
+
+import aiu_trace_analyzer.logger as aiulog
+from aiu_trace_analyzer.types import TraceEvent, TraceWarning
+from aiu_trace_analyzer.pipeline import TwoPhaseWithBarrierContext, AbstractContext
+
+
+class KernelParentVerificationContext(TwoPhaseWithBarrierContext):
+    """
+    Context for managing kernel-parent timestamp verification state.
+
+    This context extends TwoPhaseWithBarrierContext to implement a two-phase
+    verification process:
+    1. Collection Phase: Store parent event timing and count kernel events
+    2. Verification Phase: Validate kernel containment within parent bounds
+
+    The context tracks correlation IDs and their associated parent timing
+    information, enabling real-time verification of kernel events during
+    the verification phase.
+
+    Attributes:
+        queues (dict): Inherited from AbstractHashQueueContext. Maps correlation IDs
+                      to dictionaries containing:
+                      - parent_start (float): Minimum parent event start timestamp (inf if not seen)
+                      - parent_end (float): Maximum parent event end timestamp (-inf if not seen)
+                      - kernel_count (int): Number of kernels seen for this correlation ID
+        warnings (dict): Inherited from AbstractContext. Tracks verification warnings:
+                        - kernel_outside_parent: Kernels outside parent bounds (ERROR)
+                        - orphan_kernels: Kernels without parent events
+                        - orphan_parents: Parents without kernel events
+    """
+
+    def __init__(self, warnings=None):
+        """
+        Initialize the kernel-parent verification context.
+
+        Sets up warning trackers for three types of verification issues:
+        1. Kernels outside parent timeframe (marked as error)
+        2. Orphan kernels (kernels without parent events)
+        3. Orphan parents (parent events without kernels)
+
+        Args:
+            warnings (list[TraceWarning], optional): Additional warnings to track.
+                                                     Defaults to None.
+        """
+        if warnings is None:
+            warnings = []
+        warnings.extend([
+            TraceWarning(
+                name="kernel_outside_parent",
+                text="Kernel-Parent Verification: Found {d[count]} kernels outside parent timeframe",
+                data={"count": 0},
+                is_error=True  # This is a critical error that should fail verification
+            ),
+            TraceWarning(
+                name="orphan_kernels",
+                text="Kernel-Parent Verification: Found {d[count]} kernels without parent events",
+                data={"count": 0}
+            ),
+            TraceWarning(
+                name="orphan_parents",
+                text="Kernel-Parent Verification: Parent correlation IDs without kernels: {d[parents]}",
+                data={"parents": set()},
+                update_fn={"parents": lambda s, v: s | {v}},
+            )
+        ])
+        super().__init__(warnings)
+
+    def collect_parent_and_kernels(self, event: TraceEvent) -> None:
+        """
+        Collect parent timing information and track kernel events during collection phase.
+
+        This method processes events during the collection phase to build a mapping
+        of correlation IDs to their parent timing information and kernel counts.
+
+        For ScheduleCompute events (parents):
+            - Stores the start and end timestamps by correlation ID
+            - Works with both Torch ("aiuLaunchScheduleCompute") and Flex ("ScheduleCompute")
+
+        For kernel events:
+            - Increments the kernel count for the correlation ID
+            - Registers the correlation ID if not already tracked
+
+        Correlation ID 0 is ignored as it typically represents invalid or placeholder events.
+
+        Args:
+            event (TraceEvent): The trace event to process. Must be a dictionary with
+                               standard trace event fields (ph, name, cat, args, ts, dur).
+        """
+        # Only process events with correlation IDs
+        if "args" not in event or "correlation" not in event["args"]:
+            return
+
+        correlation_id = event["args"]["correlation"]
+
+        # Skip correlation ID 0 (typically invalid/placeholder)
+        if correlation_id == 0:
+            return
+
+        # Check if this is a parent ScheduleCompute or ScheduleWait event
+        # Pattern matches both Torch ("aiuLaunchScheduleCompute") and Flex ("ScheduleCompute", "ScheduleWait")
+        if "ScheduleCompute" in event["name"] or "ScheduleWait" in event["name"]:
+            # Get or create entry for this correlation ID
+            qid = self.get_or_create(
+                correlation_id,
+                {"parent_start": float('inf'), "parent_end": float('-inf'), "kernel_count": 0}
+            )
+            # Store parent timing information, tracking min start and max end
+            self.queues[qid]["parent_start"] = min(self.queues[qid]["parent_start"], event["ts"])
+            self.queues[qid]["parent_end"] = max(self.queues[qid]["parent_end"], event["ts"] + event["dur"])
+
+        # Check if this is a kernel event
+        elif "cat" in event and event["cat"] == "kernel":
+            # Get or create entry for this correlation ID
+            qid = self.get_or_create(
+                correlation_id,
+                {"parent_start": float('inf'), "parent_end": float('-inf'), "kernel_count": 0}
+            )
+            # Increment kernel count
+            self.queues[qid]["kernel_count"] += 1
+
+    def verify_kernel_containment(self, event: TraceEvent) -> None:
+        """
+        Verify that a kernel event is contained within its parent's timeframe.
+
+        This method is called during the verification phase for each kernel event.
+        It checks whether the kernel's start and end timestamps fall within the
+        bounds of its parent ScheduleCompute event.
+
+        A kernel is considered valid if:
+            kernel_start >= parent_start AND kernel_end <= parent_end
+
+        If the parent timing information is not available (orphan kernel), no
+        verification is performed here; orphans are detected in drain().
+
+        Args:
+            event (TraceEvent): The kernel event to verify. Must have:
+                               - cat == "kernel"
+                               - args.correlation: correlation ID
+                               - ts: start timestamp
+                               - dur: duration
+        """
+        # Only verify kernel events
+        if "cat" not in event or event["cat"] != "kernel":
+            return
+
+        # Must have correlation ID
+        if "args" not in event or "correlation" not in event["args"]:
+            return
+
+        correlation_id = event["args"]["correlation"]
+
+        # Skip correlation ID 0
+        if correlation_id == 0:
+            return
+
+        # Check if we have parent timing information for this correlation ID
+        if correlation_id not in self.queues:
+            aiulog.log(aiulog.ERROR, "BUG: verify_kernel_containment called for unknown correlation ID", correlation_id)
+            return
+
+        parent_data = self.queues[correlation_id]
+
+        # If parent timing is not available, this is an orphan kernel
+        if math.isinf(parent_data["parent_start"]) or math.isinf(parent_data["parent_end"]):
+            self.warnings["orphan_kernels"].update()
+            return
+
+        # Calculate kernel timing
+        kernel_start = event["ts"]
+        kernel_end = event["ts"] + event["dur"]
+        parent_start = parent_data["parent_start"]
+        parent_end = parent_data["parent_end"]
+
+        # Verify kernel is fully contained within parent bounds
+        if kernel_start < parent_start or kernel_end > parent_end:
+            # Log detailed event information
+            aiulog.log(
+                aiulog.DEBUG,
+                f"Kernel-Parent Verification: Kernel outside parent timeframe - "
+                f"Correlation ID: {correlation_id}, "
+                f"Kernel: '{event['name']}', "
+                f"Kernel time: [{kernel_start:.3f}, {kernel_end:.3f}], "
+                f"Parent time: [{parent_start:.3f}, {parent_end:.3f}]"
+            )
+            # Update warning counter
+            self.warnings["kernel_outside_parent"].update({"count": 1})
+
+    def drain(self) -> list[TraceEvent]:
+        """
+        Finalize verification and detect orphan correlation IDs.
+
+        This method is called at the end of each phase. During the collection phase,
+        it switches to the verification phase. During the verification phase, it
+        performs orphan detection:
+
+        Orphan Detection:
+            - Orphan Parents: Parent events with kernel_count == 0
+            - Orphan Kernels: Kernel events where parent_start or parent_end is infinity
+
+        After orphan detection, summary statistics are logged.
+
+        Returns:
+            list[TraceEvent]: Empty list (no events are buffered or emitted).
+        """
+        # If still in collection phase, just switch to verification phase
+        if self.collection_phase():
+            return super().drain()
+
+        for correlation_id, data in self.queues.items():
+            # Check for orphan parents (parent without kernels)
+            if data["kernel_count"] == 0 and not math.isinf(data["parent_start"]):
+                self.warnings["orphan_parents"].update({"parents": correlation_id})
+                aiulog.log(
+                    aiulog.DEBUG,
+                    "Kernel-Parent Verification: Orphan parent - "
+                    f"Correlation ID {correlation_id} has parent but no kernels"
+                )
+
+            # Check for orphan kernels (kernels without parent)
+            if data["kernel_count"] > 0 and math.isinf(data["parent_start"]):
+                self.warnings["orphan_kernels"].update({"count": data["kernel_count"]})
+                aiulog.log(
+                    aiulog.WARN,
+                    "Kernel-Parent Verification: Orphan kernels - "
+                    f"Correlation ID {correlation_id} has {data['kernel_count']} kernel(s) but no parent"
+                )
+
+        return super().drain()
+
+
+def kernel_parent_collect(event: TraceEvent, ctx: AbstractContext) -> list[TraceEvent]:
+    """
+    Collection phase: gather parent timing and track kernel events.
+
+    This pipeline function is called during the collection phase for each event.
+    It delegates to the context's collect_parent_and_kernels method to store
+    parent timing information and count kernel events by correlation ID.
+
+    All events are passed through unchanged.
+
+    Args:
+        event (TraceEvent): The trace event to process.
+        ctx (AbstractContext): Must be a KernelParentVerificationContext instance.
+
+    Returns:
+        list[TraceEvent]: Single-element list containing the input event (pass-through).
+
+    Raises:
+        AssertionError: If ctx is not a KernelParentVerificationContext instance.
+    """
+    assert isinstance(ctx, KernelParentVerificationContext), \
+        "Context must be KernelParentVerificationContext"
+
+    if event["ph"] != "X":
+        return [event]
+    ctx.collect_parent_and_kernels(event)
+    return [event]
+
+
+def kernel_parent_verify(event: TraceEvent, ctx: AbstractContext) -> list[TraceEvent]:
+    """
+    Verification phase: check kernel containment within parent bounds.
+
+    This pipeline function is called during the verification phase (after the
+    pipeline barrier) for each event. For kernel events, it verifies that the
+    kernel's timestamps fall within its parent ScheduleCompute event's timeframe.
+
+    All events are passed through unchanged.
+
+    Args:
+        event (TraceEvent): The trace event to verify.
+        ctx (AbstractContext): Must be a KernelParentVerificationContext instance.
+
+    Returns:
+        list[TraceEvent]: Single-element list containing the input event (pass-through).
+
+    Raises:
+        AssertionError: If ctx is not a KernelParentVerificationContext instance.
+    """
+    assert isinstance(ctx, KernelParentVerificationContext), \
+        "Context must be KernelParentVerificationContext"
+
+    if event["ph"] != "X":
+        return [event]
+    ctx.verify_kernel_containment(event)
+    return [event]

--- a/src/aiu_trace_analyzer/verification/kernel_parent_verify.py
+++ b/src/aiu_trace_analyzer/verification/kernel_parent_verify.py
@@ -203,9 +203,8 @@ class KernelParentVerificationContext(TwoPhaseWithBarrierContext):
 
         parent_data = self.queues[correlation_id]
 
-        # If parent timing is not available, this is an orphan kernel
+        # If parent timing is not available, this is an orphan kernel — counted in drain()
         if math.isinf(parent_data["parent_start"]) or math.isinf(parent_data["parent_end"]):
-            self.warnings["orphan_kernels"].update()
             return
 
         # Calculate kernel timing


### PR DESCRIPTION
for any kernel and schedule-wait event in the trace, the code in this PR collects information about:
 * which kernel belongs to which parent CPU event
 * is the kernel time within the boundaries of it's parent time/duration
 * are there kernels without parent event
 * are there parents without kernel events

This is useful for trace verification (therefore it is part of the verification pipeline using `-V` option) to check for incorrect timestamps.

Current implementation only prints them as warnings, e.g.:
```
2026-06-17T18:32:50.737915  WARNING Kernel-Parent Verification: Orphan kernels - Correlation ID 90 has 1 kernel(s) but no parent 
2026-06-17T18:32:50.737953  WARNING Kernel-Parent Verification: Orphan kernels - Correlation ID 91 has 150 kernel(s) but no parent 
2026-06-17T18:32:50.738497  WARNING Kernel-Parent Verification: Found 302 kernels without parent events 
```

Now that this is the first actual verification stage, I removed the use of the example dummy and also separated the verification pipeline from the default processing pipeline.

@johnuman 

