### PR TITLE
fix: pin pypa/gh-action-pypi-publish to a commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.meta.outputs.prerelease == 'false'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
Follow-up to #109 to resolve the SonarQube security hotspot.

**Hotspot:** `githubactions:S7637` — *Using external GitHub actions and workflows without a commit reference is security-sensitive.* Flagged on `.github/workflows/release.yml` line 57.

A mutable ref like `@release/v1` can be repointed at any time, so a compromise of that branch would run untrusted code with our `id-token: write` / `contents: write` permissions during a release. Pinning to a full commit SHA makes the action immutable.

**Change:**
```diff
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
```

The SHA is the commit behind the [v1.14.0](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.0) release tag. The trailing `# v1.14.0` comment keeps it human-readable and is the convention Dependabot understands for future bumps.

The `actions/checkout` and `actions/setup-python` uses are first-party GitHub-owned actions and are not flagged by the rule, so they're left as-is.